### PR TITLE
DIREM-017: prepare v0.1.0 release pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-04-29
 
 ### Added
 - Initial DIREM project skeleton.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DIREM is a Telegram-first system for regular returns to intention.
 
 Current target: `DIREM v0.1.0 — Core MVP`.
 
-This repository currently contains the DIREM shell plus the domain foundation: bot shell, worker delivery MVP, PostgreSQL, SQLAlchemy 2, Alembic, version metadata, credits metadata, user registration, persisted user timezones and languages, `/new` reminder record creation, `/list` reminder record viewing, `/pause` and `/resume` status updates, `/delete` reminder record deletion, domain constants, database models for users/reminders/deliveries/user states, and tested schedule calculation functions.
+This repository currently contains the DIREM Core MVP: bot service, worker delivery MVP, PostgreSQL, SQLAlchemy 2, Alembic, version metadata, credits metadata, user registration, persisted user timezones and languages, `/new` reminder record creation, `/list` reminder record viewing, `/pause` and `/resume` status updates, `/delete` reminder record deletion, domain constants, database models for users/reminders/deliveries/user states, and tested schedule calculation functions.
 
 Reminder delivery is now implemented as a basic MVP: the worker polls for due active reminders, sends them to the user's persisted Telegram chat, records success or failure, and advances `next_run_at` after successful sends. Retries, delivery history commands, dashboards and webhook mode are intentionally not implemented.
 
@@ -69,7 +69,7 @@ These tables support persisted reminder creation and basic worker delivery recor
 
 ## Bot Commands
 
-Available in this skeleton:
+Available in this Core MVP:
 
 - `/start`
 - `/help`
@@ -91,6 +91,7 @@ Not implemented yet:
 - delivery history command
 - delivery dashboard
 - webhook mode
+- reminder editing
 
 Implemented as schema foundation only:
 
@@ -138,7 +139,7 @@ Implemented worker delivery MVP:
 - successful sends advance `next_run_at` using the user's timezone and domain schedule functions
 - delivery message wrapper text uses the user's selected interface language
 
-Retries, AI translation, delivery history commands, dashboards and webhook mode are still not implemented.
+Retries, AI translation, delivery history commands, dashboards, webhook mode and reminder editing are still not implemented.
 
 ## Release Readiness
 
@@ -165,7 +166,7 @@ Runtime smoke summary:
 9. Send `/language`, choose Қазақша, then verify `/help` is in Kazakh.
 10. Send `/language`, choose English, then verify `/help` is in English.
 11. Send `/language`, choose Русский, then verify `/help` is in Russian.
-12. Start `/new`, then send `/cancel` and verify the flow exits.
+12. Start `/new`, verify the localized Cancel reply button appears, tap it and verify the flow exits.
 13. Set `/timezone` to `Asia/Almaty`.
 14. Create a near-due reminder through `/new`.
 15. Wait for worker delivery.
@@ -187,7 +188,7 @@ Expected:
 - `/pause` and `/resume` inline buttons update reminder status for the current Telegram user;
 - `/delete` inline confirmation removes reminder records from the current Telegram user's list;
 - worker sends due active reminders with basic MVP delivery behavior;
-- worker does not implement retries, delivery history commands or dashboards;
+- worker does not implement retries, delivery history commands, dashboards or webhook mode;
 - db container stays healthy;
 - logs do not print the Telegram token.
 

--- a/docs/releases/direm-v0.1.0.md
+++ b/docs/releases/direm-v0.1.0.md
@@ -1,0 +1,53 @@
+# DIREM v0.1.0 - Core MVP
+
+Release date: 2026-04-29
+
+## Summary
+
+DIREM v0.1.0 is the first Core MVP release of the Telegram-first reminder system. It includes the runnable bot and worker services, persisted reminder records, timezone-aware scheduling, basic worker delivery, and Russian, Kazakh and English interface language support.
+
+## Added
+
+- Telegram bot commands: `/start`, `/help`, `/language`, `/timezone`, `/new`, `/list`, `/pause`, `/resume`, `/delete`, `/version`, `/credits` and `/cancel`.
+- PostgreSQL schema and SQLAlchemy models for users, reminders, reminder deliveries and user states.
+- Alembic migrations through `20260429_003_user_language`.
+- Pure domain schedule calculation for interval and daily reminders.
+- User timezone persistence with IANA timezone validation.
+- Per-user interface language selection for Russian, Kazakh and English.
+- Reminder creation, listing, pause, resume and delete flows for the current Telegram user.
+- Inline reminder control buttons for pause, resume and delete confirmation.
+- Localized Help/Cancel reply keyboard behavior.
+- Worker delivery MVP for due active reminders with sent/failed delivery records.
+- Centralized `/version` and `/credits` metadata.
+- Runtime smoke checklist for owner-operated Telegram verification.
+
+## Known Limitations
+
+- No retry scheduler.
+- No delivery history command.
+- No delivery dashboard.
+- No webhook mode.
+- No AI translation.
+- No reminder editing.
+- No web UI.
+- Worker delivery is a basic MVP, not production-grade observability or retry infrastructure.
+- User-authored reminder title and message text are not auto-translated.
+
+## Checks
+
+- `python -m pytest` -> 110 passed.
+- `python -m compileall src alembic tests` -> passed.
+- `docker compose config` -> passed.
+- `docker compose run --rm bot alembic heads` -> `20260429_003_user_language (head)`.
+- `docker compose run --rm bot alembic current` -> `20260429_003_user_language (head)`.
+- `docker compose run --rm bot alembic upgrade head` -> passed.
+- `docker compose run --rm bot alembic current` -> `20260429_003_user_language (head)`.
+
+## Credits
+
+- Project direction: 1D1L1R
+- Architecture, scope lock and review: Rein Hard V
+- Implementation and release execution: Bushid Ronin V
+
+Credits preserved:
+1D1L1R · Rein Hard V · Bushid Ronin V

--- a/docs/tickets/DIREM-017-v0.1.0-release-pass.md
+++ b/docs/tickets/DIREM-017-v0.1.0-release-pass.md
@@ -1,0 +1,316 @@
+# DIREM-017 — v0.1.0 Release Pass
+
+## Status
+Implemented
+
+## Version target
+`DIREM v0.1.0 — Core MVP`
+
+## Workstream
+Docs / Release
+
+## Recommended branch
+`release/direm-v0.1.0`
+
+## Owner / Contributors
+
+Project Owner:
+- 1D1L1R
+
+Contributors for this ticket:
+- Rein Hard V — architecture, scope lock, review
+- Bushid Ronin V — release executor
+
+## Purpose
+
+Prepare and verify DIREM v0.1.0 Core MVP release.
+
+This ticket must not add new product features. It only verifies the current MVP state, finalizes release documentation, prepares release notes, and confirms that the repository is safe to tag.
+
+After this ticket, DIREM should be ready for the `direm-v0.1.0` release tag.
+
+## Source of truth
+
+Read before implementation:
+
+- docs/CONCEPT.md
+- docs/PRODUCT_SCOPE.md
+- docs/ARCHITECTURE.md
+- docs/VERSIONING.md
+- docs/COAUTHORS.md
+- docs/ROADMAP.md
+- docs/DECISIONS.md
+- docs/RUNTIME_SMOKE.md
+- docs/tickets/DIREM-017-v0.1.0-release-pass.md
+
+DI-CODE reference, local-only if available:
+
+- .docs-local/DI-CODE/DI-CODE_CANON.md
+- .docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md
+- .docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md
+- .docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md
+
+Important:
+
+- Follow the active ticket first.
+- Use DI-CODE_GITHUB_WORKFLOW.md for branch/commit/push rules.
+- Use DI-CODE_COMMIT-ATTRIBUTION.md for commit credits if committing.
+- Do not stage, commit or push `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## Current state / dependencies
+
+Assume these tickets are accepted and merged into `main`:
+
+- DIREM-001 — project skeleton
+- DIREM-002 — domain schema
+- DIREM-003 — schedule calculation domain
+- DIREM-004 — user registration + `/timezone`
+- DIREM-005 — `/new`
+- DIREM-006 — `/list`
+- DIREM-007 — `/pause` and `/resume`
+- DIREM-008 — `/delete`
+- DIREM-009 — worker delivery MVP
+- DIREM-010 — runtime smoke / release readiness
+- DIREM-011 — `/new` callback session injection fix
+- DIREM-012 — control active-window rendering fix
+- DIREM-013 — Telegram command menu and `/cancel`
+- DIREM-014 — inline reminder control buttons
+- DIREM-015 — language selection + ru/kk/en i18n foundation
+- DIREM-016 — pre-release Telegram UX polish
+
+Current MVP behavior:
+
+- `/start`
+- `/help`
+- `/language`
+- `/timezone`
+- `/new`
+- `/list`
+- `/pause`
+- `/resume`
+- `/delete`
+- `/version`
+- `/credits`
+- `/cancel`
+- worker delivery MVP
+- Russian / Kazakh / English interface language
+- localized Help/Cancel reply keyboard
+- inline control buttons for reminder control
+
+Still not implemented:
+
+- retry scheduler
+- AI translation
+- delivery history command
+- delivery dashboard
+- webhook mode
+- reminder editing
+- web UI
+
+## Scope
+
+### In scope
+
+- verify `main` includes all accepted D001–D016 work;
+- verify PR #3 / final help-copy micro-patch is merged before release branch starts;
+- create release branch from updated `main`;
+- run final automated checks;
+- verify migrations apply cleanly;
+- verify README truth;
+- verify CHANGELOG truth;
+- replace `[0.1.0] - Unreleased` with release date if owner approves finalization;
+- prepare release notes for `direm-v0.1.0`;
+- verify `.gitignore` excludes secrets and local DI-CODE reference docs;
+- verify `.env` is not tracked;
+- verify no local DI-CODE docs are staged;
+- verify runtime smoke checklist matches current behavior;
+- report whether `direm-v0.1.0` tag is safe to create.
+
+### Out of scope
+
+Do not implement:
+
+- new reminder features;
+- guided onboarding;
+- timezone picker by country/continent/GMT;
+- reminder editing;
+- retry scheduler;
+- delivery history command;
+- dashboard;
+- webhook mode;
+- Redis/Celery;
+- AI features;
+- web UI;
+- broad copy rewrite;
+- new runtime architecture;
+- release tag unless owner explicitly approves after release pass.
+
+## Technical requirements
+
+- no product behavior changes unless a release-blocking bug is found;
+- release-blocking bugs must be reported before fixing unless trivial docs/check typo;
+- if a real bug is found, recommend hotfix ticket instead of hiding it inside release pass;
+- do not rotate or expose tokens;
+- do not commit `.env`;
+- do not commit `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## README update
+
+README may claim:
+
+- DIREM v0.1.0 Core MVP includes current Telegram commands;
+- worker delivery is basic MVP;
+- ru/kk/en language selection exists;
+- user-authored reminder content is not auto-translated;
+- retries/history/dashboard/webhook are not implemented.
+
+README must not claim:
+
+- production-grade delivery;
+- retries;
+- dashboard;
+- delivery history;
+- webhook mode;
+- AI translation;
+- reminder editing;
+- timezone auto-detection.
+
+## CHANGELOG update
+
+CHANGELOG should finalize v0.1.0 if release pass is accepted.
+
+Suggested heading:
+
+```md
+## [0.1.0] - 2026-04-29
+
+Do not describe roadmap features as finished.
+
+Release notes
+
+Prepare release notes draft, either in report or in:
+
+docs/releases/direm-v0.1.0.md
+
+Release notes should include:
+
+Summary
+Added
+Known limitations
+Checks
+Credits
+
+Known limitations must include:
+
+no retry scheduler;
+no delivery history command;
+no dashboard;
+no webhook mode;
+no AI translation;
+no reminder editing.
+Tests
+
+Required automated checks:
+
+python -m pytest
+python -m compileall src alembic tests
+docker compose config
+
+Migration sanity:
+
+docker compose run --rm bot alembic heads
+docker compose run --rm bot alembic current
+docker compose run --rm bot alembic upgrade head
+docker compose run --rm bot alembic current
+
+Git safety checks:
+
+git status
+git diff
+git diff --cached
+git ls-files .env
+git status --ignored --short .docs-local DI-CODE docs/DI-CODE
+Manual smoke
+
+Use docs/RUNTIME_SMOKE.md.
+
+Minimum owner runtime smoke before tag:
+
+/start
+/language → Қазақша → /help
+/language → English → /help
+/language → Русский → /help
+/new → verify Cancel button → cancel
+/timezone → set Asia/Almaty
+/new → create near-due reminder
+wait for worker delivery
+/list
+/pause via inline button
+/resume via inline button
+/delete via inline button + confirmation
+verify deleted reminder disappears
+Acceptance checklist
+ Release branch starts from updated main.
+ PR #3 / D016 help-copy micro-patch is merged.
+ Automated checks pass.
+ Migration checks pass.
+ Runtime smoke checklist is current.
+ README truth is preserved.
+ CHANGELOG truth is preserved.
+ Release notes are prepared.
+ .env is not tracked.
+ .docs-local/, DI-CODE/, and docs/DI-CODE/ are not staged.
+ No new features were added.
+ No release tag was created without explicit owner approval.
+ Executor report includes branch, commit, changed files, checks, risks and push state.
+Verification commands
+python -m pytest
+python -m compileall src alembic tests
+docker compose config
+docker compose run --rm bot alembic heads
+docker compose run --rm bot alembic current
+docker compose run --rm bot alembic upgrade head
+docker compose run --rm bot alembic current
+git status
+git diff
+git diff --cached
+git ls-files .env
+git status --ignored --short .docs-local DI-CODE docs/DI-CODE
+Git / GitHub expectations
+Follow DI-CODE_GITHUB_WORKFLOW.md.
+Use release/direm-v0.1.0.
+Do not commit directly to main.
+Do not create tag until owner explicitly approves.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Report branch, commits, changed files, checks, PR state and push state.
+Implementation guard
+Implement only this release pass.
+Do not implement future roadmap items.
+Do not add new product features.
+Do not refactor unrelated areas.
+Do not hide release-blocking bugs inside release docs.
+Preserve versioning and credits metadata.
+Update README and CHANGELOG only with truthful release-state wording.
+Run required checks and report results.
+If release readiness is blocked, stop and report the blocker.
+Do not create release tag until owner explicitly approves.
+Expected result summary
+
+After this ticket:
+
+DIREM v0.1.0 release state is verified;
+release notes are prepared;
+README/CHANGELOG are truthful;
+automated checks pass;
+migration state is verified;
+repository is safe for release tag.
+
+Still not implemented after this ticket:
+
+retry scheduler;
+AI translation;
+delivery history;
+dashboard;
+webhook mode;
+reminder editing;
+web UI.


### PR DESCRIPTION
## Ticket
`docs/tickets/DIREM-017-v0.1.0-release-pass.md`

## Done
- Finalized `CHANGELOG.md` for `0.1.0` with release date `2026-04-29`.
- Updated README release truth wording for Core MVP, Cancel reply button smoke, and known limitations.
- Added release notes draft at `docs/releases/direm-v0.1.0.md`.
- Added D017 release pass ticket.
- Verified automated checks, migration state, `.env` tracking, and local DI-CODE ignore state.

## Changed Files
- `CHANGELOG.md`
- `README.md`
- `docs/releases/direm-v0.1.0.md`
- `docs/tickets/DIREM-017-v0.1.0-release-pass.md`

## Checks
- `python -m pytest` -> 110 passed
- `python -m compileall src alembic tests` -> passed
- `docker compose config` -> passed
- `docker compose run --rm bot alembic heads` -> `20260429_003_user_language (head)`
- `docker compose run --rm bot alembic current` -> `20260429_003_user_language (head)`
- `docker compose run --rm bot alembic upgrade head` -> passed
- `docker compose run --rm bot alembic current` -> `20260429_003_user_language (head)`
- `git ls-files .env` -> no tracked `.env`
- `git status --ignored --short .docs-local DI-CODE docs/DI-CODE` -> `.docs-local/` ignored

## Out Of Scope
- No product features.
- No release-blocking bug fixes hidden in release docs.
- No release tag created.
- No D017+ feature work started.

## Notes / Risks
- `direm-v0.1.0` should be tagged only after owner accepts and merges this release branch into `main`.
- Optional real Telegram runtime smoke remains owner-operated because it depends on a real local `TELEGRAM_BOT_TOKEN`.