### PR TITLE
DIREM-018: plan post-release backlog

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,139 @@
+# DIREM - Post-v0.1.0 Backlog
+
+This backlog is a planning document. Nothing here is implemented until a dedicated ticket is accepted and merged.
+
+## v0.1.1 - Polish / UX / Small Fixes
+
+### DIREM-019 - Guided First-run Onboarding
+
+Purpose:
+Help a new user understand the shortest useful path after `/start`.
+
+Likely scope:
+- friendly first-run text;
+- point to `/language`, `/timezone` and `/new`;
+- avoid a heavy tutorial.
+
+Out of scope:
+- onboarding state machine unless strictly needed;
+- new reminder features.
+
+### DIREM-020 - Timezone Picker UX
+
+Purpose:
+Reduce friction for users who do not know IANA timezone names.
+
+Likely scope:
+- guided examples;
+- common timezone shortcuts;
+- better invalid timezone recovery.
+
+Out of scope:
+- full country/continent browser unless explicitly approved;
+- automatic timezone detection.
+
+### DIREM-021 - Language and Copy Polish
+
+Purpose:
+Polish Russian, Kazakh and English user-facing copy after real runtime usage.
+
+Likely scope:
+- `/help`;
+- `/new`;
+- `/timezone`;
+- control flow prompts;
+- worker delivery wrapper.
+
+Out of scope:
+- AI translation;
+- automatic translation of user-authored reminder content.
+
+### DIREM-022 - Empty States and Confirmation Polish
+
+Purpose:
+Make empty lists, invalid choices and confirmation screens clearer.
+
+Likely scope:
+- `/list` empty state;
+- `/pause`, `/resume`, `/delete` empty states;
+- stale callback copy;
+- confirmation wording.
+
+Out of scope:
+- new commands;
+- reminder editing.
+
+## v0.2.0 - Functional Expansion
+
+### DIREM-023 - Delivery History Command
+
+Purpose:
+Let a user inspect recent reminder delivery events.
+
+Likely scope:
+- `/history` or equivalent command;
+- show recent sent/failed delivery records;
+- current Telegram user isolation.
+
+Out of scope:
+- dashboard;
+- analytics;
+- exports.
+
+### DIREM-024 - Retry Policy MVP
+
+Purpose:
+Handle failed Telegram sends more deliberately than logging and recording once.
+
+Likely scope:
+- retry eligibility rules;
+- bounded retry attempts;
+- tests for failed send behavior.
+
+Out of scope:
+- exponential backoff platform;
+- Redis/Celery unless separately approved.
+
+### DIREM-025 - Reminder Editing
+
+Purpose:
+Allow changing existing reminder title/message/schedule without delete-and-recreate.
+
+Likely scope:
+- edit selected reminder;
+- preserve user isolation;
+- recalculate `next_run_at` when schedule changes.
+
+Out of scope:
+- bulk editing;
+- web UI.
+
+### DIREM-026 - Reminder Details View
+
+Purpose:
+Show one reminder in a clearer focused view before heavier editing arrives.
+
+Likely scope:
+- select reminder by public number/id;
+- show title, message, schedule, active window, status and next run.
+
+Out of scope:
+- editing;
+- delivery history timeline.
+
+## Parked / Later
+
+- Dashboard or Telegram WebApp.
+- Webhook mode.
+- Redis/Celery queue infrastructure.
+- AI translation or generated reminder text.
+- Voice/audio features.
+- Public SaaS mode.
+- Team/shared reminder spaces.
+
+## Backlog Guard
+
+- Backlog items are not permission to implement.
+- Every item needs a dedicated ticket and branch.
+- Keep v0.1.1 small unless runtime usage proves a blocker.
+- Keep v0.2.0 focused on useful reminder operation, not platform expansion.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,506 +1,172 @@
-# DIREM — Roadmap v0.1
+# DIREM - Roadmap
 
-## 0. Назначение документа
+## 0. Purpose
 
-Этот документ фиксирует карту развития DIREM.
+This document keeps DIREM's future work organized after the `direm-v0.1.0` Core MVP release.
 
-Он нужен, чтобы:
+Roadmap entries are plans, not implemented features. Implementation still requires an active ticket, a branch, checks and review.
 
-- отделить MVP от будущих идей;
-- не тащить roadmap-фичи в первый релиз;
-- дать implementation понятный горизонт развития;
-- сохранить продуктовую логику по версиям;
-- понимать, какие решения сейчас должны быть простыми, а какие нужно оставить расширяемыми.
-
-Главное правило:
-
-> Roadmap — это направление, а не разрешение реализовывать всё сразу.
-
-Implementation может читать roadmap для контекста, но реализует только активный тикет.
-
----
-
-## 1. Общая траектория
-
-DIREM развивается поэтапно:
+Current released state:
 
 ```text
-v0.1.0 — Core MVP
-v0.2.0 — Reliability & Editing
-v0.3.0 — Templates / Rituals
-v0.4.0 — History & Reflection
-v0.5.0 — Project Pulse
-v0.6.0 — Telegram UX polish
-v0.7.0 — Optional WebApp dashboard
-v1.0.0 — Stable self-hosted release
+direm-v0.1.0 - Core MVP
 ```
 
-Смысловая траектория:
+## 1. Roadmap Guard
 
-```text
-Reminder bot
-→ Intent keeper
-→ Ritual engine
-→ Reflection/history layer
-→ Personal process pulse
-```
+- Do not implement roadmap items without an active ticket.
+- Keep docs honest: planned means planned, not shipped.
+- Prefer small post-release tickets over large mixed branches.
+- New product behavior starts from a new branch off `main`.
+- Dashboard, webhook, Redis/Celery, AI translation and web UI remain parked until explicitly activated.
 
----
+## 2. Released: v0.1.0 - Core MVP
 
-## 2. Version v0.1.0 — Core MVP
-
-### Цель
-
-Получить маленький, устойчивый, self-hosted Telegram bot, который умеет создавать, хранить и отправлять регулярные reminder-ы.
-
-### Основной результат
-
-Пользователь может:
-
-- запустить бота;
-- настроить timezone;
-- создать interval reminder;
-- создать daily reminder;
-- увидеть список reminder-ов;
-- поставить reminder на паузу;
-- возобновить reminder;
-- удалить reminder;
-- получить scheduled message;
-- посмотреть `/version`;
-- посмотреть `/credits`.
-
-### In scope
-
-- Python project skeleton;
-- Docker Compose;
-- PostgreSQL;
-- SQLAlchemy models;
-- Alembic migrations;
-- aiogram bot service;
-- worker service;
-- users;
-- reminders;
-- reminder deliveries;
-- user states / FSM;
-- `/start`;
-- `/help`;
-- `/new`;
-- `/list`;
-- `/pause`;
-- `/resume`;
-- `/delete`;
-- `/timezone`;
-- `/status`;
-- `/version`;
-- `/credits`;
-- README;
-- CHANGELOG;
-- smoke checklist.
-
-### Out of scope
-
-- edit reminder flow, если усложняет MVP;
-- web dashboard;
-- Telegram WebApp;
-- rituals/templates;
-- AI generation;
-- weekly summary;
-- integrations;
-- public SaaS;
-- payment;
-- mascot/stickers.
-
-### Release tag
+Released as tag:
 
 ```text
 direm-v0.1.0
 ```
 
----
+Implemented:
 
-## 3. Version v0.2.0 — Reliability & Editing
+- Telegram bot service and worker service.
+- PostgreSQL, SQLAlchemy 2 and Alembic migrations.
+- `/start`, `/help`, `/language`, `/timezone`, `/new`, `/list`, `/pause`, `/resume`, `/delete`, `/version`, `/credits` and `/cancel`.
+- Reminder creation, list, pause, resume and delete flows for the current Telegram user.
+- Worker delivery MVP for due active reminders.
+- Delivery records for successful and failed send attempts.
+- IANA timezone validation and persisted user timezone.
+- Russian, Kazakh and English interface language selection.
+- Localized Help/Cancel reply keyboard behavior.
+- Inline reminder control buttons.
+- Runtime smoke checklist and release notes.
 
-### Цель
+Still not implemented:
 
-Сделать базовый цикл удобнее и надёжнее после первого MVP.
+- Guided first-run onboarding.
+- Timezone picker UX.
+- Delivery history command.
+- Retry scheduler.
+- Reminder editing.
+- Dashboard.
+- Webhook mode.
+- AI translation.
+- Web UI.
 
-### Candidate features
+## 3. v0.1.1 - Polish / UX / Small Fixes
 
-- edit reminder flow;
-- better `/status`;
-- delivery retry policy;
-- safer worker claim logic;
-- better failed delivery handling;
-- improved active window handling;
-- optional overnight active windows;
-- better validation messages;
-- improved `/list` with inline actions;
-- simple admin/debug command for owner only;
-- tests for services and worker;
-- more complete smoke tests.
+Goal:
 
-### Продуктовый смысл
+Make the released Core MVP easier to use without changing the data model or adding broad new infrastructure.
 
-После v0.2.0 DIREM должен ощущаться не как прототип, а как надёжный личный бот, которым можно реально пользоваться каждый день.
+Candidate tickets:
 
-### Release tag
+1. Guided first-run onboarding.
+2. Timezone picker UX.
+3. Russian/Kazakh/English copy polish after real usage.
+4. Empty state and confirmation copy polish.
+5. Runtime smoke documentation refinements from owner testing.
+
+Scope lock:
+
+- No retries.
+- No delivery history.
+- No reminder editing.
+- No dashboard/webhook.
+- No migrations unless a small bug fix truly requires one.
+
+Expected release tag:
+
+```text
+direm-v0.1.1
+```
+
+## 4. v0.2.0 - Functional Expansion
+
+Goal:
+
+Add the first post-MVP functional capabilities while keeping the Telegram-only product shape.
+
+Candidate tickets:
+
+1. Delivery history command.
+2. Retry policy MVP.
+3. Reminder editing.
+4. Reminder details view.
+5. Safer worker observability and owner-readable diagnostics.
+
+Scope lock:
+
+- No dashboard.
+- No webhook mode.
+- No Redis/Celery unless a specific reliability ticket proves the need.
+- No AI translation.
+- No web UI.
+
+Expected release tag:
 
 ```text
 direm-v0.2.0
 ```
 
----
+## 5. Parked / Later
 
-## 4. Version v0.3.0 — Templates / Rituals
+These ideas are saved but not scheduled for the next release lanes.
 
-### Цель
+### Dashboard / Web UI
 
-Добавить шаблонные сценарии, чтобы пользователь не собирал всё вручную каждый раз.
+Possible later direction:
 
-### Candidate features
+- Telegram WebApp or separate web dashboard.
+- Visual reminder list and editing.
+- Delivery history view.
 
-- `/templates`;
-- morning check template;
-- evening reflection template;
-- project pulse template;
-- focus ping template;
-- custom template creation;
-- template preview before creation;
-- template-based reminder creation.
+Not now because Telegram-only usage should prove its limits first.
 
-### Possible built-in templates
+### Webhook Mode
 
-```text
-Morning Check
-- Что сегодня важно удержать?
-- Какой один шаг сделает день не пустым?
+Possible later direction:
 
-Evening Reflection
-- Что сегодня было сделано?
-- Что нужно перенести на завтра?
+- Webhook deployment mode for hosted environments.
 
-Project Pulse
-- Какой следующий конкретный шаг по проекту?
-- Что заблокировано?
+Not now because polling is simpler and good enough for the self-hosted MVP.
 
-Focus Return
-- Вернись к текущему вектору.
-- Что сейчас должно быть закрыто?
-```
+### Redis / Celery
 
-### Продуктовый смысл
+Possible later direction:
 
-DIREM начинает быть не просто настройщиком расписаний, а библиотекой полезных ритмов.
+- Dedicated queue and retry infrastructure.
 
-### Release tag
+Not now because the current worker is intentionally small and easier to inspect.
 
-```text
-direm-v0.3.0
-```
+### AI Translation / Generated Copy
 
----
+Possible later direction:
 
-## 5. Version v0.4.0 — History & Reflection
+- Optional generated reminder phrasing.
+- Optional interface copy assistance.
 
-### Цель
+Not now because user-authored reminder title/message content must stay stable and unmodified.
 
-Добавить слой истории: что отправлялось, когда пользователь отвечал, какие процессы реально жили.
+### Voice / Audio
 
-### Candidate features
+Possible later direction:
 
-- `/history`;
-- reminder delivery timeline;
-- user response tracking;
-- simple answer capture;
-- daily reflection log;
-- export to markdown/json;
-- view last N events;
-- reminder-level history.
+- Voice notes or audio reminders.
 
-### Data expansion
+Not now because it changes the product surface and operational complexity.
 
-Possible new entities:
+## 6. Candidate Version Sequence
 
 ```text
-reminder_responses
-intent_logs
-reflection_entries
+v0.1.0 - Core MVP - released
+v0.1.1 - UX polish and small fixes
+v0.2.0 - delivery history, retries, editing
+v0.3.0 - templates / rituals
+v0.4.0 - reflection and response history
+v0.5.0 - project pulse
+v1.0.0 - stable self-hosted release
 ```
 
-### Продуктовый смысл
-
-DIREM начинает показывать не только будущие пинги, но и след процесса во времени.
-
-### Release tag
-
-```text
-direm-v0.4.0
-```
-
----
-
-## 6. Version v0.5.0 — Project Pulse
-
-### Цель
-
-Сделать DIREM полезным для живых проектов: музыкальных, кодовых, учебных, внутренних рабочих.
-
-### Candidate features
-
-- project entity;
-- reminder grouping by project;
-- project pulse command;
-- project status note;
-- next action field;
-- blocker field;
-- lightweight project dashboard inside Telegram;
-- weekly project digest.
-
-### Possible commands
-
-```text
-/projects
-/project_new
-/project_status
-/project_pulse
-/project_archive
-```
-
-### Продуктовый смысл
-
-DIREM становится слоем регулярного возвращения не только к одиночным намерениям, но и к долгим проектам.
-
-### Release tag
-
-```text
-direm-v0.5.0
-```
-
----
-
-## 7. Version v0.6.0 — Telegram UX Polish
-
-### Цель
-
-Сделать Telegram UX быстрым, чистым и приятным.
-
-### Candidate features
-
-- better inline action menus;
-- compact reminder cards;
-- pagination for long lists;
-- quick actions: pause 1 day / pause until tomorrow / skip next;
-- duplicate reminder;
-- better confirmation screens;
-- better error messages;
-- command menu setup;
-- owner-only diagnostics;
-- optional language strings structure.
-
-### Продуктовый смысл
-
-Снижение трения. Пользователь должен управлять DIREM без ощущения, что он заполняет анкету.
-
-### Release tag
-
-```text
-direm-v0.6.0
-```
-
----
-
-## 8. Version v0.7.0 — Optional WebApp Dashboard
-
-### Цель
-
-Добавить визуальный интерфейс только если Telegram-only UX станет тесным.
-
-### Candidate features
-
-- Telegram WebApp or separate web dashboard;
-- list reminders;
-- edit reminders;
-- view history;
-- project grouping;
-- basic charts;
-- import/export;
-- owner auth.
-
-### Important lock
-
-Web dashboard не должен появиться раньше, чем Telegram MVP доказал полезность.
-
-Dashboard — не ядро DIREM, а дополнительная поверхность управления.
-
-### Release tag
-
-```text
-direm-v0.7.0
-```
-
----
-
-## 9. Version v1.0.0 — Stable self-hosted release
-
-### Цель
-
-Зафиксировать стабильную версию для длительного личного использования.
-
-### Requirements
-
-- stable Docker Compose deployment;
-- migration path from previous versions;
-- reliable worker;
-- no known duplicate-send bugs;
-- stable commands;
-- stable docs;
-- clear backup/restore instructions;
-- clear update instructions;
-- stable `/version`;
-- stable `/credits`;
-- documented configuration;
-- documented limitations.
-
-### Release tag
-
-```text
-direm-v1.0.0
-```
-
----
-
-## 10. Backlog ideas
-
-Эти идеи сохранены, но не входят в ближайший roadmap.
-
-### 10.1. AI-generated messages
-
-Возможность генерировать варианты пингов по tone/profile.
-
-Not now because:
-
-- усложняет систему;
-- требует LLM-интеграции;
-- может размыть простоту DIREM.
-
-### 10.2. External integrations
-
-Возможные интеграции:
-
-- Google Calendar;
-- Notion;
-- Todoist;
-- GitHub issues;
-- local project trackers.
-
-Not now because:
-
-- повышает сложность авторизации;
-- расширяет scope;
-- превращает DIREM в интеграционный хаб раньше времени.
-
-### 10.3. Team mode
-
-Мультипользовательские пространства, командные ритуалы, общие project pulses.
-
-Not now because:
-
-- DIREM сначала должен доказать одиночный use-case;
-- появятся роли, права, приватность, moderation.
-
-### 10.4. Public SaaS
-
-Публичный сервис с регистрацией, оплатой и хостингом для других людей.
-
-Not now because:
-
-- текущий target — self-hosted личный инструмент;
-- SaaS потребует security, billing, abuse handling, support.
-
-### 10.5. Mascot / ReMemBear layer
-
-Маскот, стикеры, playful reactions, legacy nods.
-
-Not now because:
-
-- MVP должен ощущаться как инструмент;
-- маскот может появиться позже как polish, не как core.
-
----
-
-## 11. Explicit non-roadmap
-
-Следующие вещи не являются частью roadmap DIREM:
-
-- будильник;
-- принудительный звук;
-- принудительное видео;
-- антисон-сирена;
-- desktop alarm companion;
-- mobile alarm app;
-- health/safety monitoring;
-- emergency alert system.
-
-Если такие идеи когда-либо появятся, они должны оформляться как отдельный проект, а не как расширение DIREM Core.
-
----
-
-## 12. Roadmap guard for implementation
-
-Текст для тикетов:
-
-```text
-Read docs/ROADMAP.md only for context.
-Do not implement future roadmap features unless this ticket explicitly includes them.
-Current roadmap items are not permission to expand scope.
-If a future feature seems easy to add now, do not add it without explicit approval.
-Prefer simple architecture that does not block roadmap, but do not build roadmap early.
-```
-
----
-
-## 13. Version dependency map
-
-```text
-v0.1.0 Core MVP
-  required before: everything else
-
-v0.2.0 Reliability & Editing
-  depends on: stable reminders, worker, delivery log
-
-v0.3.0 Templates / Rituals
-  depends on: stable create/list flows and schedule model
-
-v0.4.0 History & Reflection
-  depends on: delivery log and optional response capture
-
-v0.5.0 Project Pulse
-  depends on: intents/reminders/history being stable enough
-
-v0.6.0 Telegram UX Polish
-  depends on: real use pain points from v0.1-v0.5
-
-v0.7.0 Optional WebApp Dashboard
-  depends on: Telegram UX limits becoming obvious
-
-v1.0.0 Stable
-  depends on: proven daily use and clean migration path
-```
-
----
-
-## 14. Current priority
-
-Current priority is only:
-
-```text
-Ship v0.1.0 Core MVP.
-```
-
-Everything else is parked.
-
----
-
-## 15. Short lock
-
-> DIREM grows from a small reliable reminder core into an intent/ritual/history system only af
+The sequence can change after real usage. If a bug blocks daily use, it should become a patch ticket before larger features.

--- a/docs/tickets/DIREM-018-post-release-backlog-planning.md
+++ b/docs/tickets/DIREM-018-post-release-backlog-planning.md
@@ -1,0 +1,155 @@
+# DIREM-018 — Post-release Backlog Planning
+
+## Status
+Implemented
+
+## Version target
+`DIREM post-v0.1.0`
+
+## Workstream
+Docs / Release
+
+## Recommended branch
+`docs/DIREM-018-post-release-backlog-planning`
+
+## Owner / Contributors
+
+Project Owner:
+- 1D1L1R
+
+Contributors for this ticket:
+- Rein Hard V — architecture, scope lock, review
+- Bushid Ronin V — docs/release planning executor
+
+## Purpose
+
+Plan DIREM development after `direm-v0.1.0`.
+
+DIREM v0.1.0 Core MVP is released. This ticket should organize the next backlog into clear version lanes without implementing any new product behavior.
+
+## Current state
+
+Released:
+
+- `direm-v0.1.0` — Core MVP
+
+Implemented:
+
+- Telegram bot commands
+- reminder creation/list/control/delete
+- worker delivery MVP
+- ru/kk/en language selection
+- command menu
+- cancel/help reply keyboard
+- inline reminder control buttons
+- runtime smoke checklist
+
+Known limitations:
+
+- no guided onboarding
+- no timezone picker
+- no delivery history command
+- no retry scheduler
+- no reminder editing
+- no dashboard
+- no webhook mode
+- no AI translation
+- no web UI
+
+## Scope
+
+In scope:
+
+- update `docs/ROADMAP.md`;
+- optionally add `docs/BACKLOG.md` if useful;
+- split next work into version lanes:
+  - `v0.1.1` polish / UX / small fixes;
+  - `v0.2.0` functional expansion;
+  - parked / later;
+- define recommended next 5–8 tickets;
+- identify release-blocking vs nice-to-have work;
+- keep roadmap honest and non-promissory;
+- update `docs/DECISIONS.md` only if a real decision is made;
+- do not change application code.
+
+Suggested next lanes:
+
+### v0.1.1 — UX polish
+
+- Guided first-run onboarding
+- Timezone picker UX
+- Kazakh/Russian/English copy polish
+- Better empty states and quick actions
+- Maybe command/help text polish after real usage
+
+### v0.2.0 — Reminder power features
+
+- Delivery history command
+- Retry policy MVP
+- Reminder editing
+- Reminder details view
+- Safer worker observability
+
+### Parked / later
+
+- Dashboard
+- Webhook mode
+- Redis/Celery
+- AI translation
+- Web UI
+- Voice/audio features
+
+## Out of scope
+
+Do not implement:
+
+- new bot commands;
+- migrations;
+- worker changes;
+- onboarding code;
+- timezone picker code;
+- retries;
+- dashboard/webhook;
+- AI features;
+- web UI.
+
+## README update
+
+README should not change unless it contains stale roadmap wording.
+
+## CHANGELOG update
+
+No CHANGELOG update required unless existing release docs are corrected.
+
+## Acceptance criteria
+
+- post-release roadmap is clear;
+- next tickets are named and ordered;
+- v0.1.1 / v0.2.0 / parked split is understandable;
+- no code changes;
+- no false promises;
+- no release tag changes;
+- no DI-CODE local reference docs committed.
+
+## Verification commands
+
+```bash
+git status
+git diff
+
+If docs-only changes are made, automated Python checks are optional but not required unless code changed.
+
+Implementation guard
+Implement only post-release planning docs.
+Do not implement product features.
+Do not modify source code.
+Do not create release tag.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Keep roadmap honest: planned means planned, not implemented.
+Expected result summary
+
+After this ticket:
+
+DIREM has a clean post-v0.1.0 roadmap;
+next tickets are ready to be cut;
+development can continue without collapsing all future ideas into one branch.


### PR DESCRIPTION
## Ticket
`docs/tickets/DIREM-018-post-release-backlog-planning.md`

## Done
- Updated `docs/ROADMAP.md` for post-v0.1.0 planning.
- Added `docs/BACKLOG.md` with v0.1.1, v0.2.0 and parked/later lanes.
- Listed likely next tickets for onboarding, timezone UX, language/copy polish, delivery history, retry policy, editing and details view.
- Marked D018 ticket as implemented.

## Changed Files
- `docs/ROADMAP.md`
- `docs/BACKLOG.md`
- `docs/tickets/DIREM-018-post-release-backlog-planning.md`

## Checks
- `git status` -> docs-only changes before commit; branch clean after commit
- `git diff` -> docs-only diff, no code changes

## Out Of Scope
- No bot commands.
- No migrations.
- No worker changes.
- No onboarding/timezone/retry implementation.
- No dashboard/webhook/AI/web UI.
- No release tag changes.

## Notes
- PR is docs-only backlog planning after `direm-v0.1.0`.