### PR TITLE
DIREM-023: design Bunker Mode

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -63,9 +63,42 @@ Out of scope:
 - new commands;
 - reminder editing.
 
+### DIREM-023 - Bunker Mode Design
+
+Purpose:
+Design user-level Bunker Mode before implementation.
+
+Scope:
+- define activation/deactivation behavior;
+- define worker suppression behavior;
+- define reminder state restore semantics;
+- recommend data model and migration direction.
+
+Out of scope:
+- `/bunker` command;
+- migrations;
+- worker changes;
+- runtime implementation.
+
 ## v0.2.0 - Functional Expansion
 
-### DIREM-023 - Delivery History Command
+### Bunker Mode Implementation
+
+Purpose:
+Let a user temporarily silence all DIREM reminder delivery without rewriting individual reminder statuses.
+
+Likely scope:
+- user-level Bunker state;
+- worker suppression;
+- Telegram UX;
+- active reminder `next_run_at` recalculation on exit.
+
+Out of scope:
+- timed Bunker;
+- per-reminder snooze;
+- dashboard or analytics.
+
+### DIREM-024 - Delivery History Command
 
 Purpose:
 Let a user inspect recent reminder delivery events.
@@ -80,7 +113,7 @@ Out of scope:
 - analytics;
 - exports.
 
-### DIREM-024 - Retry Policy MVP
+### DIREM-025 - Retry Policy MVP
 
 Purpose:
 Handle failed Telegram sends more deliberately than logging and recording once.
@@ -94,7 +127,7 @@ Out of scope:
 - exponential backoff platform;
 - Redis/Celery unless separately approved.
 
-### DIREM-025 - Reminder Editing
+### DIREM-026 - Reminder Editing
 
 Purpose:
 Allow changing existing reminder title/message/schedule without delete-and-recreate.
@@ -108,7 +141,7 @@ Out of scope:
 - bulk editing;
 - web UI.
 
-### DIREM-026 - Reminder Details View
+### DIREM-027 - Reminder Details View
 
 Purpose:
 Show one reminder in a clearer focused view before heavier editing arrives.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -775,7 +775,7 @@ MVP должен быть ясным, коротким и функциональ
 
 ## ADR-016 — Design Bunker Mode as user-level delivery suppression
 
-Status: Proposed
+Status: Accepted
 
 ### Context
 
@@ -862,7 +862,7 @@ ADR-012 Accepted — Reject overnight active windows in MVP
 ADR-013 Accepted — Avoid catch-up storms after downtime
 ADR-014 Accepted — Keep MVP single-user friendly but multi-user capable
 ADR-015 Accepted — Keep mascot/ReMemBear out of MVP UI
-ADR-016 Proposed — Design Bunker Mode as user-level delivery suppression
+ADR-016 Accepted — Design Bunker Mode as user-level delivery suppression
 ```
 
 ---

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -773,6 +773,77 @@ MVP должен быть ясным, коротким и функциональ
 
 ---
 
+## ADR-016 — Design Bunker Mode as user-level delivery suppression
+
+Status: Proposed
+
+### Context
+
+DIREM needs a future Bunker Mode: a user-level global pause that temporarily silences reminders.
+
+The existing model already has reminder-level statuses:
+
+```text
+active
+paused
+deleted
+```
+
+Rewriting every active reminder to `paused` on Bunker activation would make restore behavior fragile. The system would need to remember which reminders were already paused, which were active, and which were created during Bunker.
+
+### Decision
+
+Design Bunker Mode as user-level delivery suppression.
+
+Recommended direction:
+
+- Bunker is per user.
+- Bunker does not rewrite reminder statuses.
+- Worker checks user Bunker state before sending.
+- Active reminders remain active but are not delivered while Bunker is on.
+- Paused reminders remain paused.
+- Deleted reminders remain deleted.
+- Reminders created during Bunker are allowed and are suppressed until exit.
+- On exit, active reminders get fresh `next_run_at` values using existing schedule calculation and no-catch-up-storm behavior.
+
+Detailed design:
+
+```text
+docs/design/DIREM-023-bunker-mode.md
+```
+
+### Rationale
+
+This keeps Bunker simple and avoids a fragile per-reminder status snapshot.
+
+The user intent is "silence DIREM for now", not "mutate all my reminders".
+
+User-level suppression also keeps reminder controls meaningful during Bunker:
+
+- `/pause` still means explicitly paused;
+- `/resume` still means explicitly active;
+- deleted reminders remain deleted;
+- worker behavior has one additional user-state check.
+
+### Consequences
+
+Pros:
+
+- simpler restore behavior;
+- less risk of losing original reminder status;
+- no delivery storm after Bunker exits;
+- clearer data model;
+- Bunker can be implemented in small tickets.
+
+Cons:
+
+- implementation needs a user-level Bunker state migration;
+- worker must check user state;
+- active reminders may remain due while Bunker is active unless query filtering is added;
+- `/list` may need future copy to explain that active reminders are currently suppressed by Bunker.
+
+---
+
 ## 16. Decision index
 
 ```text
@@ -791,6 +862,7 @@ ADR-012 Accepted — Reject overnight active windows in MVP
 ADR-013 Accepted — Avoid catch-up storms after downtime
 ADR-014 Accepted — Keep MVP single-user friendly but multi-user capable
 ADR-015 Accepted — Keep mascot/ReMemBear out of MVP UI
+ADR-016 Proposed — Design Bunker Mode as user-level delivery suppression
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -174,7 +174,7 @@ Not now because it changes the product surface and operational complexity.
 ```text
 v0.1.0 - Core MVP - released
 v0.1.1 - UX polish and small fixes
-v0.2.0 - delivery history, retries, editing
+v0.2.0 - Bunker mode, delivery history, retries, editing
 v0.3.0 - templates / rituals
 v0.4.0 - reflection and response history
 v0.5.0 - project pulse

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,6 +67,7 @@ Candidate tickets:
 3. Russian/Kazakh/English copy polish after real usage.
 4. Empty state and confirmation copy polish.
 5. Runtime smoke documentation refinements from owner testing.
+6. Bunker Mode design.
 
 Scope lock:
 
@@ -90,11 +91,12 @@ Add the first post-MVP functional capabilities while keeping the Telegram-only p
 
 Candidate tickets:
 
-1. Delivery history command.
-2. Retry policy MVP.
-3. Reminder editing.
-4. Reminder details view.
-5. Safer worker observability and owner-readable diagnostics.
+1. Bunker Mode implementation.
+2. Delivery history command.
+3. Retry policy MVP.
+4. Reminder editing.
+5. Reminder details view.
+6. Safer worker observability and owner-readable diagnostics.
 
 Scope lock:
 
@@ -123,6 +125,16 @@ Possible later direction:
 - Delivery history view.
 
 Not now because Telegram-only usage should prove its limits first.
+
+### Bunker Mode Extensions
+
+Possible later direction:
+
+- timed Bunker until a selected date/time;
+- Bunker status display in reminder lists;
+- owner diagnostics for suppressed reminders.
+
+Not in the first Bunker implementation because the initial design keeps Bunker as simple user-level delivery suppression.
 
 ### Webhook Mode
 

--- a/docs/design/DIREM-023-bunker-mode.md
+++ b/docs/design/DIREM-023-bunker-mode.md
@@ -1,0 +1,379 @@
+# DIREM-023 - Bunker Mode Design
+
+## Status
+
+Design proposal for future implementation. Bunker Mode is not implemented.
+
+## Purpose
+
+Bunker Mode is a user-level global silence mode for DIREM. It lets a user temporarily stop reminder delivery without losing the previous state of individual reminders.
+
+The design goal is simple:
+
+- one user can enter Bunker;
+- worker stops sending that user's reminders;
+- reminders are not spammed after exit;
+- reminders that were paused before Bunker stay paused;
+- deleted reminders stay deleted;
+- implementation remains Telegram-first and small.
+
+## Core Behavior
+
+Bunker Mode is per user.
+
+When Bunker is active:
+
+- worker must not send reminders for that user;
+- active reminders remain logically active in their own records;
+- paused reminders remain paused;
+- deleted reminders remain deleted;
+- reminder creation remains allowed;
+- newly created reminders can be active, but delivery is suppressed until Bunker exits;
+- manual reminder controls still work unless a future UX ticket explicitly disables them.
+
+When Bunker is inactive:
+
+- active reminders can be delivered normally;
+- paused reminders are skipped;
+- deleted reminders are skipped.
+
+## Activation
+
+Activation should require confirmation.
+
+Activation should:
+
+- set user-level Bunker state to active;
+- store `bunker_started_at`;
+- leave reminder statuses unchanged;
+- show clear Telegram confirmation.
+
+Activation should not:
+
+- rewrite every active reminder to paused;
+- create delivery records;
+- recalculate `next_run_at`;
+- delete or disable reminders.
+
+Recommended Russian copy direction:
+
+```text
+Бункер включён.
+
+DIREM пока не будет присылать напоминания.
+Индивидуальные статусы напоминаний сохранены.
+```
+
+Kazakh copy direction:
+
+```text
+Бункер қосылды.
+
+DIREM әзірге еске салуларды жібермейді.
+Еске салулардың жеке күйлері сақталады.
+```
+
+English copy direction:
+
+```text
+Bunker is on.
+
+DIREM will not send reminders for now.
+Individual reminder statuses are preserved.
+```
+
+## Deactivation
+
+Deactivation should require confirmation.
+
+Deactivation should:
+
+- set user-level Bunker state to inactive;
+- store `bunker_ended_at` or clear active state while keeping history;
+- recalculate `next_run_at` for reminders that are active at the moment of exit;
+- leave paused reminders paused;
+- leave deleted reminders deleted;
+- avoid catch-up storms.
+
+Deactivation should not:
+
+- send missed reminders immediately;
+- replay missed deliveries;
+- change paused reminders to active unless the user manually resumed them before exit;
+- create delivery records for skipped Bunker time.
+
+Recommended Russian copy direction:
+
+```text
+Бункер выключен.
+
+Активные напоминания продолжат работу с нового времени.
+Пропущенные напоминания не будут отправлены пачкой.
+```
+
+Kazakh copy direction:
+
+```text
+Бункер өшірілді.
+
+Белсенді еске салулар жаңа уақыттан жалғасады.
+Өтіп кеткен еске салулар топ болып жіберілмейді.
+```
+
+English copy direction:
+
+```text
+Bunker is off.
+
+Active reminders will continue from a fresh next run.
+Missed reminders will not be sent in a batch.
+```
+
+## Reminder State Rules
+
+### Active Reminders
+
+Active reminders stay `active` while Bunker is on.
+
+Worker suppression comes from user-level Bunker state, not from rewriting reminder status.
+
+On Bunker exit:
+
+- recalculate `next_run_at` for active reminders from `now`;
+- use the user's timezone;
+- use existing schedule calculation functions;
+- apply no-catch-up-storm behavior.
+
+### Paused Reminders
+
+Paused reminders stay `paused`.
+
+Bunker activation does not snapshot and later restore them, because their status never changes.
+
+On Bunker exit:
+
+- paused reminders remain paused;
+- `next_run_at` should not be recalculated unless a future implementation already recalculates on resume.
+
+### Deleted Reminders
+
+Deleted reminders stay deleted.
+
+Worker must already skip deleted reminders. Bunker does not change that.
+
+### Reminders Created During Bunker
+
+Reminder creation remains allowed.
+
+New reminders created during Bunker should:
+
+- be stored with the selected status from the existing creation flow, normally `active`;
+- calculate and store `next_run_at` normally;
+- not be delivered until Bunker is off;
+- have `next_run_at` recalculated on Bunker exit if they are active.
+
+Rationale:
+
+- this keeps `/new` usable;
+- user can prepare reminders while offline/silent;
+- worker has one global suppression check;
+- no special created-during-Bunker status is needed.
+
+## Snapshot and Restore Semantics
+
+Recommended direction: no per-reminder status snapshot for MVP Bunker.
+
+Because Bunker does not rewrite reminder statuses, restoration is simply:
+
+- user Bunker state becomes inactive;
+- active reminders remain active;
+- paused reminders remain paused;
+- deleted reminders remain deleted;
+- active reminders get fresh future `next_run_at`.
+
+If a future design chooses to rewrite statuses during Bunker, then a snapshot table would be needed. That is not recommended for the first implementation.
+
+## next_run_at After Exit
+
+On Bunker exit, active reminders should be recalculated as if the user is resuming from downtime.
+
+Rules:
+
+- use current UTC time as `now`;
+- use user timezone;
+- for interval reminders, next run is `now + interval`, adjusted for active window;
+- for daily reminders, next future local daily time is selected;
+- active windows are respected;
+- no catch-up storm;
+- no immediate batch delivery of missed reminders.
+
+If active window is currently closed:
+
+- schedule the next valid time inside the window;
+- do not send immediately.
+
+If schedule config is invalid:
+
+- leave reminder active but log/report implementation-level warning;
+- future implementation may surface a safe user-facing message in `/list` or a diagnostics view.
+
+## Worker Behavior
+
+Worker must check Bunker state before delivery.
+
+Recommended order:
+
+1. Find due active reminders as today.
+2. Join or load user state.
+3. If user's Bunker is active, skip delivery.
+4. Do not create delivery records for Bunker-skipped reminders in MVP.
+5. Do not advance `next_run_at` while Bunker is active.
+6. On Bunker exit, bot/service recalculates active reminders once.
+
+Rationale:
+
+- worker behavior remains easy to reason about;
+- skipped Bunker time is not treated as send failure;
+- delivery history stays honest;
+- no missed-message storm.
+
+Implementation note:
+
+If worker repeatedly finds the same due reminders while Bunker is active, this is acceptable for MVP if batch size is small. If logs become noisy, implementation can filter out Bunker users in the due query.
+
+## Telegram UX
+
+Future UX entry point:
+
+- main menu may add Bunker button;
+- command may be `/bunker`;
+- Bunker screen shows current state and actions.
+
+Suggested states:
+
+```text
+Bunker off
+Bunker on
+Turn Bunker on
+Turn Bunker off
+Confirm
+Cancel
+Back
+```
+
+Activation confirmation should explain:
+
+- reminders will be silent;
+- individual statuses are preserved;
+- new reminders can still be created.
+
+Deactivation confirmation should explain:
+
+- active reminders resume from a fresh next run;
+- missed reminders are not sent in a batch.
+
+## Data Model Direction
+
+Recommended minimal model:
+
+Add user-level fields, either on `users` or in a dedicated user settings/state table:
+
+```text
+users.bunker_active boolean not null default false
+users.bunker_started_at timestamptz nullable
+users.bunker_updated_at timestamptz nullable
+```
+
+Alternative dedicated table:
+
+```text
+user_modes
+- user_id
+- bunker_active
+- bunker_started_at
+- bunker_updated_at
+```
+
+Recommendation:
+
+- use `users` fields for the first implementation unless the project wants a broader user settings table;
+- avoid JSON snapshot for MVP;
+- avoid per-reminder snapshot table for MVP.
+
+## Migration Implications
+
+Bunker implementation requires a migration.
+
+Expected Alembic migration:
+
+- add `bunker_active`;
+- add `bunker_started_at`;
+- add `bunker_updated_at`;
+- backfill existing users to `bunker_active = false`;
+- add index only if worker query needs it after implementation profiling.
+
+No migration is part of this design ticket.
+
+## Future Tests
+
+Implementation should test:
+
+- activate Bunker for one user;
+- deactivate Bunker for one user;
+- Bunker is user-isolated;
+- worker skips active reminders for Bunker user;
+- worker still sends reminders for non-Bunker user;
+- paused reminders remain paused after exit;
+- deleted reminders remain deleted after exit;
+- reminders created during Bunker are suppressed;
+- active reminders get recalculated `next_run_at` on exit;
+- no catch-up storm after exit;
+- invalid/stale Bunker callbacks do not crash;
+- ru/kk/en copy exists.
+
+## Follow-up Implementation Tickets
+
+Recommended split:
+
+1. `DIREM-024-bunker-data-model`
+   - add user-level Bunker fields;
+   - migration;
+   - repository/service methods;
+   - schema tests.
+
+2. `DIREM-025-bunker-domain-service`
+   - activate/deactivate service;
+   - active reminder recalculation on exit;
+   - no-catch-up behavior tests.
+
+3. `DIREM-026-bunker-worker-suppression`
+   - worker skip check;
+   - user isolation tests;
+   - no delivery records for Bunker skips.
+
+4. `DIREM-027-bunker-telegram-ux`
+   - `/bunker` command or menu hub;
+   - confirmation/cancel callbacks;
+   - localized copy;
+   - runtime smoke update.
+
+## Non-goals
+
+Do not include in first Bunker implementation:
+
+- per-reminder snooze;
+- timed Bunker until a date/time;
+- global system-wide pause;
+- status snapshot/restore table unless requirements change;
+- delivery records for Bunker skips;
+- analytics/dashboard;
+- automatic detection of user availability.
+
+## Open Questions
+
+- Should Bunker have an optional duration later?
+- Should `/list` visually mark that Bunker is active?
+- Should reminder creation while Bunker is active show a small warning?
+- Should owner diagnostics show how many reminders are suppressed?
+
+These are intentionally parked for later tickets.

--- a/docs/tickets/DIREM-023-bunker-mode-design.md
+++ b/docs/tickets/DIREM-023-bunker-mode-design.md
@@ -1,0 +1,254 @@
+# DIREM-023 — Bunker Mode Design
+
+## Status
+Implemented
+
+## Version target
+`DIREM v0.1.1 / v0.2.0 planning`
+
+## Workstream
+Docs / Architecture
+
+## Recommended branch
+`docs/DIREM-023-bunker-mode-design`
+
+## Owner / Contributors
+
+Project Owner:
+- 1D1L1R
+
+Contributors for this ticket:
+- Rein Hard V — architecture, scope lock, review
+- Bushid Ronin V — design/docs executor
+
+## Purpose
+
+Design Bunker Mode before implementation.
+
+Bunker Mode is a user-level global pause feature. It should temporarily silence active reminders and later restore the user's previous reminder state.
+
+This ticket must not implement Bunker Mode. It should define behavior, edge cases, data model direction, UX, and follow-up implementation tickets.
+
+## Source of truth
+
+Read before implementation:
+
+- docs/CONCEPT.md
+- docs/PRODUCT_SCOPE.md
+- docs/ARCHITECTURE.md
+- docs/ROADMAP.md
+- docs/BACKLOG.md
+- docs/DECISIONS.md
+- docs/RUNTIME_SMOKE.md
+- docs/tickets/DIREM-023-bunker-mode-design.md
+
+DI-CODE reference:
+- `.docs-local/DI-CODE/DI-CODE_CANON.md`
+- `.docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md`
+- `.docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md`
+- `.docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md`
+
+Important:
+- Follow the active ticket first.
+- Use DI-CODE_GITHUB_WORKFLOW.md for branch/commit/push rules.
+- Do not stage, commit or push `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## Current state / dependencies
+
+Assume these are accepted and merged into `main`:
+
+- `direm-v0.1.0` — Core MVP
+- DIREM-018 — post-release backlog planning
+- DIREM-019 — guided first-run onboarding
+- DIREM-020 — timezone picker UX
+- DIREM-021 — Dorpheus copy cleanup
+- DIREM-022 — Telegram main menu and hubs
+
+Current behavior:
+
+- reminders can be active, paused and deleted;
+- worker sends due active reminders;
+- paused/deleted reminders are skipped;
+- user has persisted timezone and language;
+- Telegram menu/hubs exist;
+- no user-level global pause exists.
+
+## Scope
+
+### In scope
+
+Design Bunker Mode.
+
+Need:
+
+- define Bunker Mode concept and exact behavior;
+- decide whether Bunker is user-level only;
+- define what happens when Bunker is activated;
+- define what happens when Bunker is deactivated;
+- define how existing active/paused/deleted reminders behave;
+- define what happens to reminders created while Bunker is active;
+- define how `next_run_at` should be recalculated after exiting Bunker;
+- define how worker should skip reminders during Bunker;
+- define expected Telegram UX and copy;
+- define localization needs for ru/kk/en;
+- define data model options;
+- recommend one data model direction;
+- define migration implications;
+- define tests needed for implementation;
+- define follow-up implementation ticket split;
+- update docs/DECISIONS.md with ADR if a decision is accepted;
+- update docs/BACKLOG.md / docs/ROADMAP.md if needed.
+
+### Out of scope
+
+Do not implement:
+
+- `/bunker` command;
+- Bunker menu button behavior;
+- migrations;
+- database models;
+- worker changes;
+- reminder service changes;
+- status snapshot code;
+- Telegram callbacks;
+- tests for runtime code;
+- release tag changes.
+
+## Design questions to answer
+
+### Core behavior
+
+- Is Bunker global per user?
+- Does Bunker pause all reminders or only active reminders?
+- Should already paused reminders remain paused after Bunker exits?
+- Should deleted reminders be ignored?
+- Should new reminders created during Bunker be:
+  - immediately paused;
+  - active but suppressed by user bunker state;
+  - or rejected until Bunker exits?
+
+### Snapshot behavior
+
+- What exactly is stored when Bunker activates?
+- Is snapshot per reminder status enough?
+- Do we need `previous_status` for every reminder?
+- Should snapshot be stored as JSON, separate table, or state rows?
+
+### Exit behavior
+
+- On Bunker deactivate, which reminders become active again?
+- Which remain paused?
+- How should `next_run_at` be recalculated?
+- Should no-catch-up-storm helper be applied?
+- What happens if active window is currently closed?
+
+### Worker behavior
+
+- Should worker check user-level bunker state before delivery?
+- Should worker ignore reminders in Bunker without changing reminder status?
+- Should Bunker create delivery records or not? Probably not.
+
+### UX behavior
+
+Main menu top-level future button:
+
+```text
+[Бункер 🟢/🔴]
+
+Possible states:
+
+Бункер выключен;
+Бункер активен;
+Activate Bunker;
+Deactivate Bunker;
+confirm activation;
+confirm deactivation.
+
+Need to decide if activation requires confirmation.
+
+Localization
+
+Design copy for:
+
+Russian;
+Kazakh;
+English.
+Recommended design direction
+
+Executor should propose a recommended approach, but initial preference is:
+
+Bunker is per-user;
+Bunker does not rewrite every reminder status if avoidable;
+Worker checks user-level bunker state and skips delivery;
+A snapshot is stored only if reminders statuses need restoration;
+Reminders that were paused before Bunker remain paused after exit;
+Active reminders resume with recalculated next_run_at;
+No catch-up storm after exit.
+Deliverables
+
+Expected docs:
+
+docs/design/DIREM-023-bunker-mode.md or equivalent;
+ADR entry in docs/DECISIONS.md if a decision is made;
+optional update to docs/BACKLOG.md / docs/ROADMAP.md;
+this ticket file.
+README update
+
+No README update required unless design docs introduce a parked feature note.
+
+README must not claim Bunker Mode is implemented.
+
+CHANGELOG update
+
+No CHANGELOG update required unless docs policy says planning docs are tracked there.
+
+Do not claim Bunker Mode is added.
+
+Tests
+
+No runtime tests required because this is design-only.
+
+If test plan is documented, include intended future tests:
+
+activate Bunker;
+skip worker delivery;
+preserve paused reminders;
+restore active reminders;
+recalculate next_run_at;
+handle reminders created during Bunker.
+Verification commands
+git status
+git diff
+
+If code files change, stop and report.
+
+Acceptance checklist
+ Bunker Mode behavior is clearly defined.
+ Data model direction is recommended.
+ Worker behavior is defined.
+ UX behavior is defined.
+ Edge cases are listed.
+ Follow-up implementation tickets are proposed.
+ README does not claim Bunker is implemented.
+ No source code was changed.
+ No migration was added.
+ No release tag was created.
+ No local DI-CODE reference docs were staged.
+Implementation guard
+Design only.
+Do not implement Bunker Mode.
+Do not add bot commands.
+Do not add callbacks.
+Do not add migrations.
+Do not modify worker logic.
+Do not modify reminder logic.
+Do not update README as if Bunker exists.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+If design reveals implementation needs, propose follow-up tickets.
+Expected result summary
+
+After this ticket:
+
+Bunker Mode is scoped and designed;
+implementation risks are known;
+next implementation tickets can be cut safely.


### PR DESCRIPTION
## Ticket
`docs/tickets/DIREM-023-bunker-mode-design.md`

## Done
- Added Bunker Mode design document.
- Defined per-user Bunker behavior, activation/deactivation, reminder state rules and reminders-created-during-Bunker behavior.
- Defined snapshot/restore semantics without bulk reminder status rewrite.
- Defined `next_run_at` recalculation after exit and no-catch-up-storm behavior.
- Defined worker suppression behavior while Bunker is active.
- Added Telegram UX and ru/kk/en copy direction.
- Recommended data model and migration direction.
- Added proposed ADR and backlog/roadmap planning updates.

## Changed files
- `docs/design/DIREM-023-bunker-mode.md`
- `docs/DECISIONS.md`
- `docs/BACKLOG.md`
- `docs/ROADMAP.md`
- `docs/tickets/DIREM-023-bunker-mode-design.md`

## Checks
- `git status` -> clean after commit
- `git diff` -> reviewed before commit

## Out of scope
- No `/bunker` command.
- No menu button logic or callbacks.
- No migrations.
- No worker changes.
- No reminder service changes.
- No runtime tests.
- No release tag.

## Notes / risks
- ADR-016 is marked Proposed because this ticket designs Bunker Mode; implementation/acceptance can promote it later if owner/reviewer wants.
- Recommended design avoids per-reminder status rewrite and uses user-level delivery suppression instead.