### PR TITLE
DIREM-024: add Bunker state foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Lightweight localized first-run onboarding after `/start`.
 - Lightweight `/timezone` picker with common timezone buttons while preserving manual IANA input.
 - Localized Telegram main menu and navigation hubs for reminders, settings and help.
+- Internal user-level Bunker state foundation for future global reminder suppression.
 
 ### Changed
 - Removed stale `Dorpheus` references from DIREM examples and tests.

--- a/alembic/versions/20260503_004_add_user_bunker_state.py
+++ b/alembic/versions/20260503_004_add_user_bunker_state.py
@@ -1,0 +1,32 @@
+"""add user bunker state
+
+Revision ID: 20260503_004_bunker_state
+Revises: 20260429_003_user_language
+Create Date: 2026-05-03
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260503_004_bunker_state"
+down_revision: str | None = "20260429_003_user_language"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("bunker_active", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "users",
+        sa.Column("bunker_activated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "bunker_activated_at")
+    op.drop_column("users", "bunker_active")

--- a/docs/tickets/DIREM-024-bunker-state-foundation.md
+++ b/docs/tickets/DIREM-024-bunker-state-foundation.md
@@ -1,0 +1,235 @@
+# DIREM-024 — Bunker State Foundation
+
+## Status
+Ready for implementation
+
+## Version target
+`DIREM v0.2.0 — Bunker Mode foundation`
+
+## Workstream
+Backend / Domain
+
+## Recommended branch
+`feature/DIREM-024-bunker-state-foundation`
+
+## Owner / Contributors
+
+Project Owner:
+- 1D1L1R
+
+Contributors for this ticket:
+- Rein Hard V — architecture, scope lock, review
+- Bushid Ronin V — implementation executor
+
+## Purpose
+
+Add the data and service foundation for future Bunker Mode.
+
+Bunker Mode was accepted as user-level delivery suppression:
+- do not rewrite individual reminder statuses;
+- store whether the user is currently in Bunker;
+- future worker logic will skip deliveries for users with active Bunker;
+- future UI will expose Bunker controls.
+
+This ticket adds only the persistence and service layer needed for that future behavior.
+
+## Source of truth
+
+Read before implementation:
+
+- docs/CONCEPT.md
+- docs/ARCHITECTURE.md
+- docs/DECISIONS.md
+- docs/design/DIREM-023-bunker-mode.md
+- docs/BACKLOG.md
+- docs/ROADMAP.md
+- docs/tickets/DIREM-024-bunker-state-foundation.md
+
+DI-CODE reference:
+- `.docs-local/DI-CODE/DI-CODE_CANON.md`
+- `.docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md`
+- `.docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md`
+- `.docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md`
+
+Important:
+
+- Follow the active ticket first.
+- Use DI-CODE_GITHUB_WORKFLOW.md for branch/commit/push rules.
+- Do not stage, commit or push `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## Current state / dependencies
+
+Assume these are accepted and merged into `main`:
+
+- DIREM-023 — Bunker Mode Design
+
+Current behavior:
+
+- reminders have statuses such as active, paused and deleted;
+- worker sends due active reminders;
+- no user-level Bunker state exists yet;
+- no worker suppression exists yet;
+- no Telegram Bunker UI exists yet.
+
+## Scope
+
+### In scope
+
+Add Bunker state persistence and domain/service foundation.
+
+Need:
+
+- add user-level Bunker state to persistence;
+- add Alembic migration;
+- add SQLAlchemy model fields or model/table according to the accepted design;
+- add repository methods for reading/updating Bunker state;
+- add service methods for:
+  - checking current Bunker state;
+  - activating Bunker;
+  - deactivating Bunker;
+  - idempotent behavior if already active/inactive;
+- store activation timestamp where useful;
+- keep all timestamps UTC;
+- do not mutate reminder statuses;
+- do not recalculate `next_run_at` yet;
+- add tests for repository/service behavior;
+- update docs if needed;
+- update CHANGELOG.
+
+Recommended simple model direction:
+
+Add fields to `users` unless implementation finds a strong reason for a separate table:
+
+```text
+users.bunker_active BOOLEAN NOT NULL DEFAULT false
+users.bunker_activated_at TIMESTAMPTZ NULL
+
+Expected behavior:
+
+new users default to bunker_active = false;
+activating Bunker sets bunker_active = true and bunker_activated_at = now UTC;
+activating when already active is safe/idempotent;
+deactivating Bunker sets bunker_active = false;
+deactivating when already inactive is safe/idempotent;
+reminder statuses are not changed.
+Out of scope
+
+Do not implement:
+
+/bunker command;
+menu button;
+Telegram callbacks;
+worker delivery suppression;
+reminder next_run_at recalculation on exit;
+Bunker status in /list;
+Bunker runtime smoke;
+Bunker notification copy;
+timed Bunker;
+per-reminder snooze;
+dashboard/webhook;
+retry/history/editing features;
+release tag.
+
+Future tickets:
+
+D025 — Worker Suppression for Bunker Mode;
+D026 — Telegram Bunker UX / Menu Integration;
+D027 — Bunker Runtime Smoke & Polish.
+Technical requirements
+Keep model change minimal.
+Keep service/repository methods testable.
+Keep timestamps timezone-aware UTC.
+Preserve existing user registration behavior.
+Preserve existing language/timezone behavior.
+Do not change reminder statuses.
+Do not touch worker delivery logic in this ticket.
+Do not touch Telegram menu logic in this ticket except docs/changelog if needed.
+If the accepted design appears to require a separate table instead of users columns, report in the plan before implementation.
+Data / model changes
+
+Expected migration:
+
+add bunker_active;
+add bunker_activated_at.
+
+No destructive changes.
+
+Existing users should default to not in Bunker.
+
+README update
+
+README update is optional.
+
+README may say only if needed:
+
+Bunker state foundation exists internally.
+
+README must not claim:
+
+Bunker Mode is available to users;
+worker suppression works;
+Telegram Bunker button exists.
+CHANGELOG update
+
+Add under [Unreleased]:
+
+- Added internal user-level Bunker state foundation for future global reminder suppression.
+
+Do not say Bunker Mode is user-facing yet.
+
+Tests
+
+Required tests:
+
+new user defaults to Bunker inactive;
+activate Bunker sets active state and activation timestamp;
+activating twice is safe;
+deactivate Bunker clears active state;
+deactivating twice is safe;
+existing timezone/language user behavior still works;
+reminder statuses are not modified by Bunker state service.
+Verification commands
+python -m pytest
+python -m compileall src alembic tests
+docker compose config
+docker compose run --rm bot alembic upgrade head
+git status
+git diff
+Git / GitHub expectations
+Follow DI-CODE_GITHUB_WORKFLOW.md.
+Use feature/DIREM-024-bunker-state-foundation.
+Do not commit directly to main.
+Do not create a release tag.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Report branch, commit, changed files, checks and push state.
+Acceptance checklist
+ Bunker state persistence exists.
+ Migration is added and applies cleanly.
+ Existing users default to Bunker inactive.
+ Repository/service foundation exists.
+ Activate/deactivate behavior is idempotent.
+ Reminder statuses are not mutated.
+ Worker behavior is unchanged.
+ Telegram UI is unchanged.
+ CHANGELOG is truthful.
+ Tests pass.
+ No local DI-CODE reference docs were staged.
+ No release tag was created.
+Implementation guard
+Implement only Bunker state foundation.
+Do not implement Telegram Bunker UI.
+Do not implement worker suppression.
+Do not mutate reminder statuses.
+Do not recalculate next_run_at.
+Do not implement timed Bunker.
+Do not implement delivery history/retries/editing.
+Do not add dashboard/webhook/AI/web UI.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+If data model direction conflicts with D023 design, stop and report.
+Expected result summary
+
+After this ticket:
+
+DIREM can persist whether a user is in Bunker;
+service/repository methods exist for future Bunker implementation;
+worker/UI behavior remains unchanged until follow-up tickets.

--- a/src/direm/db/models.py
+++ b/src/direm/db/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, JSON, String, Text, Time, func
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, JSON, String, Text, Time, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from direm.domain.constants import DeliveryStatus, ReminderStatus
@@ -17,6 +17,8 @@ class User(Base):
     first_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     timezone: Mapped[str] = mapped_column(String(64), default="UTC", nullable=False)
     language_code: Mapped[str] = mapped_column(String(8), default="ru", nullable=False)
+    bunker_active: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false", nullable=False)
+    bunker_activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/direm/repositories/users.py
+++ b/src/direm/repositories/users.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+
+from sqlalchemy import select
+
 from direm.db.models import User
 from direm.repositories.base import Repository
-from sqlalchemy import select
 
 
 class UserRepository(Repository[User]):
@@ -55,5 +58,20 @@ class UserRepository(Repository[User]):
 
     async def update_language(self, user: User, language_code: str) -> User:
         user.language_code = language_code
+        await self.session.flush()
+        return user
+
+    async def get_bunker_state(self, user: User) -> tuple[bool, datetime | None]:
+        return user.bunker_active, user.bunker_activated_at
+
+    async def activate_bunker(self, user: User, *, activated_at: datetime) -> User:
+        user.bunker_active = True
+        user.bunker_activated_at = activated_at
+        await self.session.flush()
+        return user
+
+    async def deactivate_bunker(self, user: User) -> User:
+        user.bunker_active = False
+        user.bunker_activated_at = None
         await self.session.flush()
         return user

--- a/src/direm/services/bunker_service.py
+++ b/src/direm/services/bunker_service.py
@@ -1,0 +1,47 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from direm.db.models import User
+from direm.repositories.users import UserRepository
+
+
+@dataclass(frozen=True)
+class BunkerState:
+    active: bool
+    activated_at: datetime | None
+
+
+class BunkerService:
+    def __init__(
+        self,
+        user_repository: UserRepository,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.user_repository = user_repository
+        self.clock = clock or (lambda: datetime.now(UTC))
+
+    async def get_current_state(self, user: User) -> BunkerState:
+        active, activated_at = await self.user_repository.get_bunker_state(user)
+        return BunkerState(active=active, activated_at=activated_at)
+
+    async def activate(self, user: User) -> BunkerState:
+        if user.bunker_active and user.bunker_activated_at is not None:
+            return await self.get_current_state(user)
+
+        activated = await self.user_repository.activate_bunker(user, activated_at=self._now_utc())
+        return BunkerState(active=activated.bunker_active, activated_at=activated.bunker_activated_at)
+
+    async def deactivate(self, user: User) -> BunkerState:
+        if not user.bunker_active and user.bunker_activated_at is None:
+            return await self.get_current_state(user)
+
+        deactivated = await self.user_repository.deactivate_bunker(user)
+        return BunkerState(active=deactivated.bunker_active, activated_at=deactivated.bunker_activated_at)
+
+    def _now_utc(self) -> datetime:
+        now = self.clock()
+        if now.tzinfo is None:
+            return now.replace(tzinfo=UTC)
+        return now.astimezone(UTC)

--- a/tests/unit/test_bunker_service.py
+++ b/tests/unit/test_bunker_service.py
@@ -1,0 +1,171 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from direm.db.base import Base
+from direm.db.models import Reminder
+from direm.domain.constants import ReminderStatus, ScheduleType
+from direm.repositories.users import UserRepository
+from direm.services.bunker_service import BunkerService
+from direm.services.user_service import TelegramUserProfile, UserService
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    yield async_sessionmaker(engine, expire_on_commit=False)
+
+    await engine.dispose()
+
+
+async def create_user(session):
+    return await UserService(UserRepository(session)).register_or_update_from_telegram(
+        TelegramUserProfile(
+            telegram_user_id=1001,
+            chat_id=2001,
+            username="first",
+            first_name="First",
+            language_code="en",
+        )
+    )
+
+
+async def test_new_user_defaults_to_bunker_inactive(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session)
+        state = await BunkerService(UserRepository(session)).get_current_state(user)
+
+        assert user.bunker_active is False
+        assert user.bunker_activated_at is None
+        assert state.active is False
+        assert state.activated_at is None
+
+
+async def test_activate_sets_active_state_and_utc_timestamp(session_factory) -> None:
+    now = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+    async with session_factory() as session:
+        user = await create_user(session)
+        service = BunkerService(UserRepository(session), clock=lambda: now)
+
+        state = await service.activate(user)
+
+        assert state.active is True
+        assert state.activated_at == now
+        assert state.activated_at.tzinfo == UTC
+        assert user.bunker_active is True
+        assert user.bunker_activated_at == now
+
+
+async def test_activate_is_idempotent_and_keeps_original_timestamp(session_factory) -> None:
+    first = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+    second = datetime(2026, 5, 3, 10, 0, tzinfo=UTC)
+    async with session_factory() as session:
+        user = await create_user(session)
+        service = BunkerService(UserRepository(session), clock=lambda: first)
+        await service.activate(user)
+
+        service = BunkerService(UserRepository(session), clock=lambda: second)
+        state = await service.activate(user)
+
+        assert state.active is True
+        assert state.activated_at == first
+        assert user.bunker_activated_at == first
+
+
+async def test_activate_repairs_active_state_without_timestamp(session_factory) -> None:
+    now = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+    async with session_factory() as session:
+        user = await create_user(session)
+        user.bunker_active = True
+        user.bunker_activated_at = None
+        service = BunkerService(UserRepository(session), clock=lambda: now)
+
+        state = await service.activate(user)
+
+        assert state.active is True
+        assert state.activated_at == now
+
+
+async def test_deactivate_clears_active_state_and_timestamp(session_factory) -> None:
+    now = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+    async with session_factory() as session:
+        user = await create_user(session)
+        service = BunkerService(UserRepository(session), clock=lambda: now)
+        await service.activate(user)
+
+        state = await service.deactivate(user)
+
+        assert state.active is False
+        assert state.activated_at is None
+        assert user.bunker_active is False
+        assert user.bunker_activated_at is None
+
+
+async def test_deactivate_is_idempotent(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session)
+        service = BunkerService(UserRepository(session))
+
+        first = await service.deactivate(user)
+        second = await service.deactivate(user)
+
+        assert first.active is False
+        assert first.activated_at is None
+        assert second.active is False
+        assert second.activated_at is None
+        assert user.bunker_active is False
+        assert user.bunker_activated_at is None
+
+
+async def test_repeated_start_preserves_bunker_state(session_factory) -> None:
+    now = datetime(2026, 5, 3, 9, 0, tzinfo=UTC)
+    async with session_factory() as session:
+        user_service = UserService(UserRepository(session))
+        user = await create_user(session)
+        await user_service.update_timezone(user, "Asia/Almaty")
+        await user_service.update_language(user, "kk")
+        await BunkerService(UserRepository(session), clock=lambda: now).activate(user)
+
+        updated = await user_service.register_or_update_from_telegram(
+            TelegramUserProfile(
+                telegram_user_id=1001,
+                chat_id=3001,
+                username="second",
+                first_name="Second",
+                language_code="ru",
+            )
+        )
+
+        assert updated.id == user.id
+        assert updated.chat_id == 3001
+        assert updated.timezone == "Asia/Almaty"
+        assert updated.language_code == "kk"
+        assert updated.bunker_active is True
+        assert updated.bunker_activated_at == now
+
+
+async def test_bunker_service_does_not_mutate_reminder_status(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session)
+        reminder = Reminder(
+            user_id=user.id,
+            title="Morning focus",
+            message_text="Return to intent.",
+            schedule_type=ScheduleType.INTERVAL.value,
+            interval_minutes=30,
+            timezone=user.timezone,
+            status=ReminderStatus.PAUSED.value,
+            next_run_at=datetime(2026, 5, 3, 9, 30, tzinfo=UTC),
+        )
+        session.add(reminder)
+        await session.flush()
+
+        service = BunkerService(UserRepository(session))
+        await service.activate(user)
+        await service.deactivate(user)
+
+        assert reminder.status == ReminderStatus.PAUSED.value


### PR DESCRIPTION
## Ticket

`docs/tickets/DIREM-024-bunker-state-foundation.md`

## Done

- Add user-level Bunker state fields and Alembic migration.
- Add `BunkerService` and `BunkerState` value object.
- Add repository methods for reading, activating and deactivating Bunker state.
- Keep activate/deactivate idempotent.
- Preserve reminder statuses and leave worker/UI behavior unchanged.
- Update CHANGELOG.

## Changed Files Summary

- `src/direm/db/models.py`
- `src/direm/repositories/users.py`
- `src/direm/services/bunker_service.py`
- `alembic/versions/20260503_004_add_user_bunker_state.py`
- `tests/unit/test_bunker_service.py`
- `docs/tickets/DIREM-024-bunker-state-foundation.md`
- `CHANGELOG.md`

## Checks

- `python -m pytest`
- `python -m compileall src alembic tests`
- `docker compose config`
- `docker compose run --rm bot alembic upgrade head`

## Out Of Scope

- `/bunker` command
- Telegram UI/menu/callbacks
- Worker suppression
- Reminder status mutation
- `next_run_at` recalculation
- Release tag

## Notes / Risks

- `activate` preserves the original `bunker_activated_at` when Bunker is already active.
- Docker Alembic verification required rebuilding the `bot` image so the container could see the new migration.