### PR TITLE
DIREM-030: prepare v0.2.0 release pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-03
+
 ### Added
 - Lightweight localized first-run onboarding after `/start`.
 - Expanded `/timezone` picker with Kazakhstan shortcuts, curated region lists and clearer UTC/GMT wording while preserving manual IANA input.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 DIREM is a Telegram-first system for regular returns to intention.
 
-Current target: `DIREM v0.1.0 — Core MVP`.
+Current release state: `DIREM v0.2.0 — Bunker and UX polish`.
 
 This repository currently contains the DIREM Core MVP: bot service, worker delivery MVP, PostgreSQL, SQLAlchemy 2, Alembic, version metadata, credits metadata, user registration with lightweight first-run guidance, persisted user timezones and languages, `/new` reminder record creation, `/list` reminder record viewing, `/pause` and `/resume` status updates, `/delete` reminder record deletion, domain constants, database models for users/reminders/deliveries/user states, and tested schedule calculation functions.
 

--- a/docs/RUNTIME_SMOKE.md
+++ b/docs/RUNTIME_SMOKE.md
@@ -1,6 +1,6 @@
 # Runtime Smoke Checklist
 
-This checklist prepares DIREM v0.1.0 for a real Telegram runtime smoke.
+This checklist prepares DIREM v0.2.0 for a real Telegram runtime smoke.
 
 ## Required Automated Checks
 

--- a/docs/releases/direm-v0.2.0.md
+++ b/docs/releases/direm-v0.2.0.md
@@ -1,0 +1,58 @@
+# DIREM v0.2.0 - Bunker and UX Polish
+
+Release date: 2026-05-03
+
+## Summary
+
+DIREM v0.2.0 builds on the Core MVP with a more usable Telegram experience, Bunker Mode, expanded timezone selection, home status stats, and release-ready docs. Reminder delivery remains a basic worker MVP, now with user-level Bunker suppression and safe rescheduling when Bunker is turned off.
+
+## Added
+
+- Lightweight localized first-run onboarding after `/start`.
+- Expanded `/timezone` picker with Kazakhstan shortcuts, curated region lists for Kazakhstan, Russia, Europe, Asia, America and UTC / GMT, plus manual IANA input.
+- Localized Telegram main menu and List, Settings and Help hubs.
+- Bunker Mode design and accepted ADR.
+- User-level Bunker persistence fields and service foundation.
+- Worker suppression for reminders owned by users with active Bunker state.
+- Telegram `/bunker` UX and direct Bunker ON/OFF reply-keyboard toggle.
+- Atomic Bunker deactivation rescheduling for active reminders to avoid catch-up delivery.
+- Home status reminder stats for the current Telegram user.
+- Main menu navigation on final/action-result messages.
+- README hero image under `docs/assets/direm-readme-hero.png`.
+
+## Changed
+
+- Removed stale `Dorpheus` references from DIREM examples and tests.
+- Refined README and runtime smoke docs for the current v0.2.0 behavior.
+
+## Known Limitations
+
+- No timed Bunker.
+- No per-reminder snooze.
+- No Bunker history.
+- No delivery history command.
+- No retry scheduler.
+- No reminder editing.
+- No dashboard or webhook mode.
+- No AI or web UI.
+- Worker delivery remains a basic MVP, not production-grade observability or retry infrastructure.
+- User-authored reminder title and message text are not auto-translated.
+
+## Checks
+
+- `python -m pytest` -> 176 passed.
+- `python -m compileall src alembic tests` -> passed.
+- `docker compose config` -> passed.
+- `docker compose run --rm bot alembic heads` -> `20260503_004_bunker_state (head)`.
+- `docker compose run --rm bot alembic current` -> `20260503_004_bunker_state (head)`.
+- `docker compose run --rm bot alembic upgrade head` -> passed.
+- `docker compose run --rm bot alembic current` -> `20260503_004_bunker_state (head)`.
+
+## Credits
+
+- Project direction: 1D1L1R
+- Architecture, scope lock and review: Rein Hard V
+- Implementation and release execution: Bushid Ronin V
+
+Credits preserved:
+1D1L1R · Rein Hard V · Bushid Ronin V

--- a/docs/tickets/DIREM-030-v0.2.0-release-pass.md
+++ b/docs/tickets/DIREM-030-v0.2.0-release-pass.md
@@ -1,0 +1,194 @@
+# DIREM-030 — v0.2.0 Release Pass
+
+## Status
+Ready for implementation
+
+## Version target
+DIREM v0.2.0
+
+## Workstream
+Docs / Release
+
+## Recommended branch
+release/direm-v0.2.0
+
+## Purpose
+
+Prepare DIREM v0.2.0 release after the post-v0.1.0 feature batch.
+
+This is a release pass only. Do not add product features.
+
+## Source of truth
+
+Read before implementation:
+
+- README.md
+- CHANGELOG.md
+- docs/RUNTIME_SMOKE.md
+- docs/ROADMAP.md
+- docs/BACKLOG.md
+- docs/DECISIONS.md
+- docs/releases/direm-v0.1.0.md
+- docs/tickets/DIREM-030-v0.2.0-release-pass.md
+
+DI-CODE reference:
+- `.docs-local/DI-CODE/DI-CODE_CANON.md`
+- `.docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md`
+- `.docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md`
+- `.docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md`
+
+Do not stage, commit or push `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## Current release baseline
+
+Released:
+
+- `direm-v0.1.0`
+
+Expected included changes since v0.1.0:
+
+- lightweight first-run onboarding;
+- expanded timezone picker with curated region lists;
+- localized main menu and hubs;
+- stale Dorpheus cleanup;
+- Bunker Mode design;
+- Bunker state foundation;
+- worker suppression for Bunker-active users;
+- Telegram Bunker UX;
+- Bunker deactivation rescheduling;
+- home status reminder stats;
+- direct Bunker ON/OFF reply-keyboard toggle;
+- README hero image.
+
+## Scope
+
+In scope:
+
+- verify `main` includes all accepted work through D029;
+- run final automated checks;
+- run Alembic migration sanity checks;
+- verify README truth;
+- verify CHANGELOG truth;
+- verify RUNTIME_SMOKE truth;
+- prepare `docs/releases/direm-v0.2.0.md`;
+- finalize CHANGELOG section for `0.2.0`;
+- verify `.env` is not tracked;
+- verify `.docs-local/`, `DI-CODE/`, `docs/DI-CODE/` are not staged;
+- verify README hero image asset is intentionally tracked and no old `images/` folder is tracked;
+- report whether `direm-v0.2.0` tag is safe to create.
+
+Out of scope:
+
+- new features;
+- Bunker history;
+- timed Bunker;
+- per-reminder snooze;
+- delivery history;
+- retry scheduler;
+- reminder editing;
+- dashboard/webhook;
+- AI/web UI;
+- release tag creation unless owner explicitly approves after review.
+
+## CHANGELOG
+
+Finalize `[Unreleased]` into:
+
+```md
+## [0.2.0] - 2026-05-03
+
+Keep only truthful completed items.
+
+After finalization, leave a fresh:
+
+## [Unreleased]
+
+above it if the changelog style supports that.
+
+Release notes
+
+Create:
+
+docs/releases/direm-v0.2.0.md
+
+Include:
+
+Summary
+Added
+Changed
+Known limitations
+Checks
+Credits
+
+Known limitations must include:
+
+no timed Bunker;
+no per-reminder snooze;
+no Bunker history;
+no delivery history command;
+no retry scheduler;
+no reminder editing;
+no dashboard/webhook;
+no AI/web UI.
+Checks
+
+Required:
+
+python -m pytest
+python -m compileall src alembic tests
+docker compose config
+docker compose run --rm bot alembic heads
+docker compose run --rm bot alembic current
+docker compose run --rm bot alembic upgrade head
+docker compose run --rm bot alembic current
+git status
+git diff
+git diff --cached
+git ls-files .env
+git status --ignored --short .docs-local DI-CODE docs/DI-CODE
+git ls-files images
+git ls-files docs/assets
+Manual smoke
+
+Use docs/RUNTIME_SMOKE.md.
+
+Minimum owner smoke before tag:
+
+/start;
+verify home status stats;
+verify Bunker OFF/ON direct reply toggle;
+verify Bunker suppresses due reminder delivery;
+verify turning Bunker off reschedules active reminders without catch-up;
+/timezone → other regions → Russia/Europe/Asia/America/UTC;
+/new;
+/list;
+/pause;
+/resume;
+/delete;
+/version;
+/credits.
+Acceptance checklist
+ Release branch starts from updated main.
+ D029 is merged before release branch starts.
+ Automated checks pass.
+ Alembic checks pass.
+ README is truthful.
+ CHANGELOG is finalized for 0.2.0.
+ Release notes are prepared.
+ Runtime smoke checklist matches current behavior.
+ .env is not tracked.
+ Local DI-CODE refs are not staged.
+ README hero asset is tracked intentionally.
+ Old images/ folder is not tracked.
+ No new features were added.
+ No release tag was created without owner approval.
+ Executor reports branch, commit, changed files, checks and tag safety.
+Implementation guard
+
+Design/release pass only.
+
+Do not implement product features.
+Do not create release tag.
+Do not modify runtime behavior.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+If a release blocker appears, stop and report.


### PR DESCRIPTION
Ticket: `docs/tickets/DIREM-030-v0.2.0-release-pass.md`

Done:
- Finalize CHANGELOG for v0.2.0 dated 2026-05-03
- Update README and runtime smoke release truth
- Add release notes for `direm-v0.2.0`
- Verify automated checks, Docker config and Alembic migration state
- Verify `.env`, local DI-CODE refs, README hero asset and old images safety

Checks:
- `python -m pytest` -> 176 passed
- `python -m compileall src alembic tests` -> passed
- `docker compose config` -> passed
- `docker compose run --rm bot alembic heads` -> `20260503_004_bunker_state (head)`
- `docker compose run --rm bot alembic current` -> `20260503_004_bunker_state (head)`
- `docker compose run --rm bot alembic upgrade head` -> passed
- `docker compose run --rm bot alembic current` -> `20260503_004_bunker_state (head)`

Out of scope:
- No product features
- No runtime behavior changes
- No release tag

Tag safety:
- `direm-v0.2.0` should be safe to tag after this PR is reviewed and merged into `main`.