### PR TITLE
DIREM-031: design response check-ins

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,104 +1,29 @@
-# DIREM - Post-v0.1.0 Backlog
+# DIREM - Post-v0.2.0 Backlog
 
 This backlog is a planning document. Nothing here is implemented until a dedicated ticket is accepted and merged.
 
-## v0.1.1 - Polish / UX / Small Fixes
+## Shipped Through v0.2.0
 
-### DIREM-019 - Guided First-run Onboarding
+These lines are historical context, not open backlog.
 
-Purpose:
-Help a new user understand the shortest useful path after `/start`.
+Released:
 
-Likely scope:
-- friendly first-run text;
-- point to `/language`, `/timezone` and `/new`;
-- avoid a heavy tutorial.
+- `direm-v0.1.0` - Core MVP.
+- `direm-v0.2.0` - Bunker and UX polish.
 
-Out of scope:
-- onboarding state machine unless strictly needed;
-- new reminder features.
+Notable shipped work:
 
-### DIREM-020 - Timezone Picker UX
+- guided first-run onboarding;
+- timezone picker UX and curated region picker;
+- language and copy polish;
+- Bunker Mode design and implementation;
+- worker suppression while Bunker is active;
+- home status screen and main menu hubs;
+- README hero image and v0.2.0 release notes.
 
-Purpose:
-Reduce friction for users who do not know IANA timezone names.
+## Post-v0.2.0 Open Backlog
 
-Likely scope:
-- guided examples;
-- common timezone shortcuts;
-- better invalid timezone recovery.
-
-Out of scope:
-- full country/continent browser unless explicitly approved;
-- automatic timezone detection.
-
-### DIREM-021 - Language and Copy Polish
-
-Purpose:
-Polish Russian, Kazakh and English user-facing copy after real runtime usage.
-
-Likely scope:
-- `/help`;
-- `/new`;
-- `/timezone`;
-- control flow prompts;
-- worker delivery wrapper.
-
-Out of scope:
-- AI translation;
-- automatic translation of user-authored reminder content.
-
-### DIREM-022 - Empty States and Confirmation Polish
-
-Purpose:
-Make empty lists, invalid choices and confirmation screens clearer.
-
-Likely scope:
-- `/list` empty state;
-- `/pause`, `/resume`, `/delete` empty states;
-- stale callback copy;
-- confirmation wording.
-
-Out of scope:
-- new commands;
-- reminder editing.
-
-### DIREM-023 - Bunker Mode Design
-
-Purpose:
-Design user-level Bunker Mode before implementation.
-
-Scope:
-- define activation/deactivation behavior;
-- define worker suppression behavior;
-- define reminder state restore semantics;
-- recommend data model and migration direction.
-
-Out of scope:
-- `/bunker` command;
-- migrations;
-- worker changes;
-- runtime implementation.
-
-## v0.2.0 - Functional Expansion
-
-### Bunker Mode Implementation
-
-Purpose:
-Let a user temporarily silence all DIREM reminder delivery without rewriting individual reminder statuses.
-
-Likely scope:
-- user-level Bunker state;
-- worker suppression;
-- Telegram UX;
-- active reminder `next_run_at` recalculation on exit.
-
-Out of scope:
-- timed Bunker;
-- per-reminder snooze;
-- dashboard or analytics.
-
-### DIREM-024 - Delivery History Command
+### Delivery History Command
 
 Purpose:
 Let a user inspect recent reminder delivery events.
@@ -113,7 +38,7 @@ Out of scope:
 - analytics;
 - exports.
 
-### DIREM-025 - Retry Policy MVP
+### Retry Policy MVP
 
 Purpose:
 Handle failed Telegram sends more deliberately than logging and recording once.
@@ -127,7 +52,7 @@ Out of scope:
 - exponential backoff platform;
 - Redis/Celery unless separately approved.
 
-### DIREM-026 - Reminder Editing
+### Reminder Editing
 
 Purpose:
 Allow changing existing reminder title/message/schedule without delete-and-recreate.
@@ -141,7 +66,7 @@ Out of scope:
 - bulk editing;
 - web UI.
 
-### DIREM-027 - Reminder Details View
+### Reminder Details View
 
 Purpose:
 Show one reminder in a clearer focused view before heavier editing arrives.
@@ -153,6 +78,109 @@ Likely scope:
 Out of scope:
 - editing;
 - delivery history timeline.
+
+## v0.3.0 - Response Check-ins / Reflection Foundation
+
+### DIREM-031 - Response Check-ins Design
+
+Purpose:
+Design Response Check-ins as a separate DIREM domain concept before implementation.
+
+Scope:
+- define Reminder / Delivery / Check-in relationships;
+- choose entity and table naming direction;
+- define MVP response types;
+- define Bunker and repeat-click behavior;
+- split future implementation tickets.
+
+Out of scope:
+- migrations;
+- Telegram callbacks;
+- history command;
+- text responses;
+- snooze.
+
+### DIREM-032 - Check-in Data Foundation
+
+Purpose:
+Add persistence for user responses to delivered reminders.
+
+Likely scope:
+- `ReminderCheckIn` model;
+- `reminder_checkins` migration;
+- response type constants;
+- repository/service skeleton;
+- schema and service tests.
+
+Out of scope:
+- worker delivery buttons;
+- history command;
+- text responses;
+- snooze.
+
+### DIREM-033 - Check-in Buttons MVP
+
+Purpose:
+Let a user mark a delivered reminder as done, later or skipped.
+
+Likely scope:
+- inline buttons on successful reminder deliveries;
+- callback handler;
+- user isolation;
+- repeat-click behavior;
+- localized confirmations.
+
+Out of scope:
+- changing reminder schedules;
+- delivery history command;
+- free-text response capture.
+
+### DIREM-034 - Check-in History Command
+
+Purpose:
+Show recent reminder deliveries and user check-ins.
+
+Likely scope:
+- user-scoped history view;
+- recent check-ins;
+- delivery/check-in status display.
+
+Out of scope:
+- analytics dashboard;
+- exports;
+- AI summaries.
+
+### DIREM-035 - Text Check-ins
+
+Purpose:
+Allow optional user-authored response text after a reminder delivery.
+
+Likely scope:
+- text capture flow;
+- persistence in nullable response text;
+- privacy/copy rules;
+- tests for preserving user-authored content.
+
+Out of scope:
+- automatic translation;
+- AI summarization;
+- public sharing.
+
+### DIREM-036 - Snooze / Later Scheduling
+
+Purpose:
+Define and implement real snooze behavior separately from the MVP `later` response.
+
+Likely scope:
+- explicit snooze choices;
+- schedule mutation rules;
+- no-catch-up-storm behavior;
+- tests for next run calculation.
+
+Out of scope:
+- treating D031/D033 `later` as implicit snooze;
+- retry scheduler;
+- dashboard.
 
 ## Parked / Later
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -844,7 +844,79 @@ Cons:
 
 ---
 
-## 16. Decision index
+## ADR-017 — Model response check-ins as a separate reminder-domain entity
+
+Status: Accepted
+
+### Context
+
+DIREM now sends reminder messages and records delivery attempts.
+
+The next product layer is letting the user respond to a delivered ping with a small signal such as:
+
+```text
+done
+later
+skipped
+```
+
+If this is modeled only as temporary Telegram callback handling, the concept will be hard to query, test and extend. If it is modeled as a task completion system, DIREM will drift toward task-manager semantics.
+
+### Decision
+
+Model user responses as a separate reminder-domain entity:
+
+```text
+ReminderCheckIn
+```
+
+Recommended table:
+
+```text
+reminder_checkins
+```
+
+Conceptual split:
+
+```text
+Reminder = recurring intention rule and schedule
+Delivery = one concrete sent reminder message
+Check-in = user's response to that delivery
+```
+
+Detailed design:
+
+```text
+docs/design/DIREM-031-response-checkins.md
+```
+
+### Rationale
+
+This keeps response capture explicit without turning DIREM into a task manager.
+
+`ReminderCheckIn` is specific enough to stay in the reminder domain, but separate enough from deliveries to support future history, text responses and reflection features.
+
+`later` is only a recorded response in MVP. It is not snooze and must not mutate reminder scheduling until a dedicated snooze ticket defines that behavior.
+
+### Consequences
+
+Pros:
+
+- clean domain separation;
+- simple future history queries;
+- clear place for response types and user isolation;
+- no hidden schedule mutation from response buttons;
+- Bunker-suppressed reminders naturally have no delivery and no check-in.
+
+Cons:
+
+- future implementation needs a migration and new repository/service layer;
+- callbacks must validate delivery, reminder and user ownership;
+- history and text responses need their own tickets.
+
+---
+
+## 17. Decision index
 
 ```text
 ADR-001 Accepted — Use Python 3.12 + aiogram 3
@@ -863,11 +935,12 @@ ADR-013 Accepted — Avoid catch-up storms after downtime
 ADR-014 Accepted — Keep MVP single-user friendly but multi-user capable
 ADR-015 Accepted — Keep mascot/ReMemBear out of MVP UI
 ADR-016 Accepted — Design Bunker Mode as user-level delivery suppression
+ADR-017 Accepted — Model response check-ins as a separate reminder-domain entity
 ```
 
 ---
 
-## 17. Scope guard for implementation
+## 18. Scope guard for implementation
 
 Text for tickets:
 
@@ -881,7 +954,7 @@ Keep the MVP small and aligned with accepted decisions.
 
 ---
 
-## 18. Short lock
+## 19. Short lock
 
 > DIREM decisions are intentionally boring: small stack, clear services, UTC time, visible versions, no legacy port, no sirens, no dashboard in MVP.  
 > The goal is not to impress the architecture gods.  

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,14 +2,14 @@
 
 ## 0. Purpose
 
-This document keeps DIREM's future work organized after the `direm-v0.1.0` Core MVP release.
+This document keeps DIREM's future work organized after the `direm-v0.2.0` release.
 
 Roadmap entries are plans, not implemented features. Implementation still requires an active ticket, a branch, checks and review.
 
 Current released state:
 
 ```text
-direm-v0.1.0 - Core MVP
+direm-v0.2.0 - Bunker and UX polish
 ```
 
 ## 1. Roadmap Guard
@@ -54,20 +54,20 @@ Still not implemented:
 - AI translation.
 - Web UI.
 
-## 3. v0.1.1 - Polish / UX / Small Fixes
+## 3. Completed Post-v0.1.0 Polish
 
 Goal:
 
-Make the released Core MVP easier to use without changing the data model or adding broad new infrastructure.
+Make the released Core MVP easier to use without changing the product into a platform.
 
-Candidate tickets:
+Shipped during the v0.2.0 cycle:
 
 1. Guided first-run onboarding.
-2. Timezone picker UX.
-3. Russian/Kazakh/English copy polish after real usage.
-4. Empty state and confirmation copy polish.
-5. Runtime smoke documentation refinements from owner testing.
-6. Bunker Mode design.
+2. Timezone picker UX and curated region picker.
+3. Russian/Kazakh/English copy polish after runtime usage.
+4. Main menu and hub navigation.
+5. Home status screen with user reminder stats.
+6. Runtime smoke documentation refinements from owner testing.
 
 Scope lock:
 
@@ -75,44 +75,67 @@ Scope lock:
 - No delivery history.
 - No reminder editing.
 - No dashboard/webhook.
-- No migrations unless a small bug fix truly requires one.
 
-Expected release tag:
+## 4. Released: v0.2.0 - Bunker and UX Polish
 
-```text
-direm-v0.1.1
-```
-
-## 4. v0.2.0 - Functional Expansion
-
-Goal:
-
-Add the first post-MVP functional capabilities while keeping the Telegram-only product shape.
-
-Candidate tickets:
-
-1. Bunker Mode implementation.
-2. Delivery history command.
-3. Retry policy MVP.
-4. Reminder editing.
-5. Reminder details view.
-6. Safer worker observability and owner-readable diagnostics.
-
-Scope lock:
-
-- No dashboard.
-- No webhook mode.
-- No Redis/Celery unless a specific reliability ticket proves the need.
-- No AI translation.
-- No web UI.
-
-Expected release tag:
+Released as tag:
 
 ```text
 direm-v0.2.0
 ```
 
-## 5. Parked / Later
+Implemented:
+
+- Bunker state foundation.
+- Worker suppression for Bunker-active users.
+- Telegram Bunker UX.
+- Atomic Bunker exit rescheduling for active reminders.
+- Home status and Bunker reply-keyboard toggle.
+- Main menu navigation polish.
+- Timezone picker v2 with curated regions.
+- README hero image and v0.2.0 release docs.
+
+Still not implemented:
+
+- Delivery history command.
+- Retry scheduler.
+- Reminder editing.
+- Reminder details view.
+- Dashboard.
+- Webhook mode.
+- Redis/Celery unless a specific reliability ticket proves the need.
+- AI translation.
+- Web UI.
+
+## 5. v0.3.0 - Response Check-ins / Reflection Foundation
+
+Goal:
+
+Let DIREM record how a user responded to delivered reminders while keeping reminder scheduling separate from response capture.
+
+Candidate tickets:
+
+1. Check-in data foundation.
+2. Check-in buttons MVP for delivered reminders.
+3. Check-in history command.
+4. Text check-ins.
+5. Snooze / Later scheduling as a separate feature after response capture is proven.
+
+Scope lock:
+
+- `later` is a recorded response, not snooze, until a dedicated snooze ticket is accepted.
+- No analytics dashboard.
+- No AI summaries.
+- No task-manager completion model.
+- No reminder editing unless covered by its own active ticket.
+
+Expected release tag:
+
+```text
+direm-v0.3.0
+```
+
+## 6. Parked / Later
 
 These ideas are saved but not scheduled for the next release lanes.
 
@@ -169,15 +192,15 @@ Possible later direction:
 
 Not now because it changes the product surface and operational complexity.
 
-## 6. Candidate Version Sequence
+## 7. Candidate Version Sequence
 
 ```text
 v0.1.0 - Core MVP - released
-v0.1.1 - UX polish and small fixes
-v0.2.0 - Bunker mode, delivery history, retries, editing
-v0.3.0 - templates / rituals
-v0.4.0 - reflection and response history
-v0.5.0 - project pulse
+v0.2.0 - Bunker mode and UX polish - released
+v0.3.0 - response check-ins and reflection foundation
+v0.4.0 - delivery history, retries, editing
+v0.5.0 - templates / rituals
+v0.6.0 - project pulse
 v1.0.0 - stable self-hosted release
 ```
 

--- a/docs/design/DIREM-031-response-checkins.md
+++ b/docs/design/DIREM-031-response-checkins.md
@@ -1,0 +1,326 @@
+# DIREM-031 - Response Check-ins Design
+
+## Status
+
+Accepted design direction for future implementation. Response Check-ins are not implemented by this document.
+
+## Purpose
+
+Response Check-ins add a small response layer after DIREM delivers a reminder.
+
+The goal is to let a user mark what happened after a delivered ping without turning DIREM into a task manager, habit tracker or analytics dashboard.
+
+Core split:
+
+```text
+Reminder = recurring intention rule and schedule
+Delivery = one concrete send attempt for a reminder
+Check-in = user's response to a delivered reminder
+```
+
+Example:
+
+```text
+Reminder
+- title: Morning focus
+- schedule: every 60 minutes
+
+Delivery
+- sent_at: 2026-05-03 10:00 UTC
+- status: sent
+
+ReminderCheckIn
+- response_type: done
+- responded_at: 2026-05-03 10:04 UTC
+```
+
+## Entity Naming
+
+Recommended domain entity:
+
+```text
+ReminderCheckIn
+```
+
+Recommended table:
+
+```text
+reminder_checkins
+```
+
+Reasoning:
+
+- `ReminderCheckIn` keeps the concept tied to the reminder domain.
+- It avoids generic `Response`, which may later conflict with API or Telegram response language.
+- It avoids `Task`, `Assignment` or `Completion`, which would pull DIREM toward task-manager semantics.
+- UI copy can still use softer words such as "response", "mark", "check-in" or "reaction".
+
+## Relationship Model
+
+Recommended relationship:
+
+```text
+users 1--N reminder_checkins
+reminders 1--N reminder_checkins
+reminder_deliveries 1--0/1 reminder_checkins
+```
+
+Each MVP check-in should link to:
+
+- `user_id`;
+- `reminder_id`;
+- `reminder_delivery_id`.
+
+`reminder_delivery_id` is the primary semantic anchor because the user responds to a concrete sent message.
+
+`reminder_id` and `user_id` should still be stored directly for:
+
+- simple user-scoped queries;
+- reminder-scoped history;
+- easier integrity checks in callbacks;
+- future reporting without always joining through deliveries.
+
+Future implementation should enforce that the linked delivery belongs to the same user and reminder.
+
+## Data Model Direction
+
+Draft table:
+
+```text
+reminder_checkins
+  id bigint primary key
+  user_id bigint not null references users(id)
+  reminder_id bigint not null references reminders(id)
+  reminder_delivery_id bigint not null references reminder_deliveries(id)
+  response_type text not null
+  response_text text null
+  created_at timestamptz not null
+  updated_at timestamptz null
+```
+
+Recommended constraints:
+
+```text
+unique(reminder_delivery_id)
+response_type in ('done', 'later', 'skipped')
+```
+
+Recommended indexes:
+
+```text
+index(user_id, created_at desc)
+index(reminder_id, created_at desc)
+```
+
+The unique delivery constraint makes the MVP behavior one check-in per delivery. Repeat taps update the same record instead of creating duplicates.
+
+Optional later fields:
+
+```text
+source
+metadata_json
+telegram_message_id
+```
+
+Do not add these until a ticket needs them.
+
+## MVP Response Types
+
+MVP response types:
+
+```text
+done
+later
+skipped
+```
+
+Meanings:
+
+- `done` means the user acted on or acknowledged the reminder.
+- `later` means the user is recording "not now" for this ping.
+- `skipped` means the user intentionally declines this ping.
+
+Do not add a `pending` check-in record in MVP. Pending is the absence of a check-in for a sent delivery.
+
+## Later Is Not Snooze
+
+In MVP, `later` is only a recorded response.
+
+It must not:
+
+- mutate `next_run_at`;
+- create a one-off delayed delivery;
+- pause or resume the reminder;
+- override the reminder's schedule;
+- create retry-like behavior.
+
+Rationale:
+
+- Snooze changes scheduling semantics and needs its own design.
+- DIREM already has no-catch-up-storm rules; hidden snooze behavior would make delivery timing harder to reason about.
+- A simple recorded `later` signal is enough to prove whether response capture is useful.
+
+Future snooze should be a separate ticket with explicit schedule rules.
+
+## Text Responses Are Postponed
+
+Free-text responses are out of MVP.
+
+Reasons:
+
+- They require input capture rules and state management.
+- They raise moderation/privacy/export questions.
+- They need a clear history view before they become useful.
+- They may invite AI summaries, which are explicitly out of scope for now.
+
+The draft table keeps `response_text` nullable so a future text check-in ticket can extend the model without renaming the entity.
+
+## Telegram UX Direction
+
+Future delivery messages should include inline response buttons only after a successful delivery record exists.
+
+MVP buttons:
+
+```text
+Done
+Later
+Skipped
+```
+
+Localization direction:
+
+```text
+ru: Готово / Позже / Пропущено
+kk: Дайын / Кейін / Өткізілді
+en: Done / Later / Skipped
+```
+
+The exact copy can be polished in the implementation ticket.
+
+Callback data should be compact and safe. Recommended direction:
+
+```text
+checkin:<delivery_id>:<response_type>
+```
+
+The callback handler must:
+
+- load the delivery;
+- verify it belongs to the current Telegram user;
+- verify the linked reminder is not deleted;
+- upsert the check-in;
+- answer stale or invalid callbacks without crashing.
+
+## Repeat-click Behavior
+
+MVP behavior:
+
+- one current check-in per delivery;
+- tapping the same response again is idempotent;
+- tapping a different response updates the existing check-in to the new response type;
+- `updated_at` changes when the response type changes;
+- no duplicate check-in rows are created.
+
+User-facing behavior:
+
+- first tap: confirm the selected response;
+- same tap again: friendly "already marked" response;
+- different tap: friendly "updated" response.
+
+This keeps the UI forgiving without adding a full edit flow.
+
+## Bunker Interaction
+
+Bunker-active users do not receive reminder deliveries.
+
+Therefore:
+
+- Bunker-suppressed reminders do not create delivery records;
+- no response buttons are shown for suppressed reminders;
+- no check-in records are created for suppressed reminders;
+- Bunker suppression is not `skipped`;
+- exiting Bunker reschedules active reminders using the existing Bunker/no-catch-up behavior, not check-ins.
+
+If a delivery message was sent before Bunker was activated, its check-in buttons may still be tapped later. The handler should accept the response if the delivery belongs to the user and the reminder still exists. Bunker state should not retroactively invalidate an already sent delivery.
+
+## Reminder Status Interaction
+
+Check-ins must not mutate reminder status in MVP.
+
+Rules:
+
+- `done` does not pause or complete a reminder;
+- `later` does not snooze a reminder;
+- `skipped` does not delete or pause a reminder;
+- deleted reminders should reject stale callbacks cleanly;
+- paused reminders may still have old sent deliveries with valid historical check-ins.
+
+## History Direction
+
+History is out of scope for the first data/button implementation, but the model should support it.
+
+Likely future views:
+
+- recent check-ins for the current user;
+- check-ins for one reminder;
+- delivery + check-in timeline;
+- weekly/project pulse later.
+
+Do not implement `/history` in the data foundation ticket unless the active ticket explicitly says so.
+
+## Implementation Ticket Split
+
+Recommended follow-up sequence:
+
+1. `DIREM-032-checkin-data-foundation`
+   - add `ReminderCheckIn` model;
+   - add Alembic migration;
+   - add response-type constants;
+   - add repository/service upsert/read skeleton;
+   - schema and service tests.
+
+2. `DIREM-033-checkin-buttons-mvp`
+   - add inline buttons to successful worker deliveries;
+   - add callback handler;
+   - enforce user isolation;
+   - handle stale callbacks;
+   - localize button labels and confirmations.
+
+3. `DIREM-034-checkin-history-command`
+   - add user-scoped history command or hub entry;
+   - show recent deliveries with check-in state;
+   - keep pagination small if needed.
+
+4. `DIREM-035-text-checkins`
+   - capture optional free-text response;
+   - define state flow and privacy/copy rules;
+   - preserve user-authored content exactly.
+
+5. `DIREM-036-snooze-later-scheduling`
+   - design and implement real snooze separately from `later`;
+   - define schedule mutation rules;
+   - avoid catch-up storms and hidden retries.
+
+## Non-goals
+
+Do not include in the initial check-in implementation:
+
+- migrations in this design ticket;
+- Telegram callbacks in this design ticket;
+- history command in the data foundation ticket;
+- free-text response capture in MVP buttons;
+- snooze behavior;
+- analytics/dashboard;
+- AI summaries;
+- reminder editing;
+- task manager semantics.
+
+## Open Questions
+
+- Should old delivery buttons expire after a fixed time?
+- Should a check-in be allowed after reminder deletion for historical accuracy, or rejected for simplicity?
+- Should `later` eventually offer fixed snooze choices?
+- Should history show deliveries with no check-in as "no response" or hide them by default?
+- Should response buttons include compact icons, plain words or both?
+
+These questions should be answered in the relevant implementation tickets, not in D031.

--- a/docs/tickets/DIREM-031-response-checkins-design.md
+++ b/docs/tickets/DIREM-031-response-checkins-design.md
@@ -1,0 +1,302 @@
+# DIREM-031 — Response Check-ins Design
+
+## Status
+Ready for design
+
+## Version target
+DIREM v0.3.0 planning
+
+## Workstream
+Docs / Architecture / Product
+
+## Recommended branch
+docs/DIREM-031-response-checkins-design
+
+## Purpose
+
+Design Response Check-ins before implementation.
+
+DIREM currently sends reminder messages. The next product layer is letting the user respond to a delivered reminder with a simple signal such as:
+
+- done;
+- later;
+- skipped.
+
+This should become a separate domain concept, not just temporary inline button handling.
+
+The goal of this ticket is to define the entity, behavior, data model direction, UX, edge cases and follow-up implementation tickets.
+
+Do not implement runtime code in this ticket.
+
+## Source of truth
+
+Read before implementation:
+
+- docs/CONCEPT.md
+- docs/ARCHITECTURE.md
+- docs/DECISIONS.md
+- docs/BACKLOG.md
+- docs/ROADMAP.md
+- docs/RUNTIME_SMOKE.md
+- docs/tickets/DIREM-031-response-checkins-design.md
+
+DI-CODE reference:
+- `.docs-local/DI-CODE/DI-CODE_CANON.md`
+- `.docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md`
+- `.docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md`
+- `.docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md`
+
+Do not stage, commit or push `.docs-local/`, `DI-CODE/`, or `docs/DI-CODE/`.
+
+## Current state
+
+DIREM v0.2.0 is released.
+
+Current implemented flow:
+
+- user creates reminders;
+- worker sends due reminders;
+- reminder deliveries are recorded;
+- user can list/pause/resume/delete reminders;
+- Bunker can suppress delivery;
+- no user response/check-in entity exists yet.
+
+## Product direction
+
+DIREM should evolve from:
+
+```text
+DIREM sends a reminder.
+
+to:
+
+DIREM sends a reminder and records how the user responded to the ping.
+
+This should not turn DIREM into a task manager.
+
+Recommended language:
+
+domain entity: CheckIn or ReminderCheckIn;
+avoid naming it Task / Assignment in domain code;
+UI can use friendly words like “response”, “mark”, “check-in”, “reaction”.
+Conceptual model
+
+Recommended conceptual split:
+
+Reminder = schedule/rule for recurring intention return
+Delivery = one concrete sent reminder message
+CheckIn = user's response to that delivery
+
+Example:
+
+Reminder:
+  title: "Return to project"
+  schedule: every 60 min
+
+Delivery:
+  sent_at: 14:00
+
+CheckIn:
+  response_type: done
+  responded_at: 14:03
+Scope
+In scope
+
+Design:
+
+entity name;
+relationship to reminders and deliveries;
+response types;
+button UX;
+data model direction;
+Telegram callback behavior;
+repeat-click behavior;
+localization direction;
+follow-up implementation tickets.
+
+Answer these design questions:
+
+Entity naming:
+ReminderCheckIn?
+ReminderResponse?
+CheckIn?
+Relationship:
+Should check-in always link to reminder_delivery_id?
+Should it also duplicate reminder_id and user_id for query convenience?
+Response types:
+done;
+later;
+skipped;
+maybe none / pending?
+MVP behavior:
+Can user respond once per delivery?
+Can user change response after tapping?
+What happens on repeated tap?
+Does later reschedule reminder or only records reaction?
+Text responses:
+Should free text be in MVP?
+Or postponed to later ticket?
+History:
+Where should check-ins be shown later?
+/history?
+reminder details?
+weekly/project pulse later?
+Worker integration:
+delivered reminders should include inline response buttons;
+buttons should only appear when delivery record exists;
+callback data must be compact and safe.
+Bunker interaction:
+Bunker-suppressed reminders produce no delivery;
+therefore no check-in buttons and no check-in record.
+Recommended initial direction
+
+Initial recommendation for future implementation:
+
+Entity
+
+Use:
+
+ReminderCheckIn
+
+Table:
+
+reminder_checkins
+
+Reason:
+
+clearer than generic responses;
+tied to reminder domain;
+does not sound like task manager.
+Table draft
+reminder_checkins
+  id
+  user_id
+  reminder_id
+  reminder_delivery_id
+  response_type
+  response_text nullable
+  created_at
+  updated_at nullable
+
+Optional later fields:
+
+metadata_json
+source
+Response types for MVP
+done
+later
+skipped
+
+Meaning:
+
+done — user acted on / acknowledged the reminder;
+later — user wants to postpone mentally, but D031/D032 should not implement snooze;
+skipped — user intentionally ignored/declined this ping.
+
+Important:
+
+In MVP, later is only a recorded response.
+It must not change reminder schedule or next_run_at.
+Snooze is a separate future feature.
+Text responses
+
+Out of MVP.
+
+Future ticket:
+
+DIREM-034 — Text Check-ins
+History
+
+Out of MVP.
+
+Future ticket:
+
+DIREM-033 — Check-in History Command
+Out of scope
+
+Do not implement:
+
+migration;
+model;
+repository;
+runtime buttons;
+worker changes;
+Telegram callbacks;
+/history;
+text response capture;
+snooze behavior;
+analytics;
+dashboard/webhook;
+AI summaries;
+reminder editing;
+release tag.
+Deliverables
+
+Create design doc:
+
+docs/design/DIREM-031-response-checkins.md
+
+Update if needed:
+
+docs/DECISIONS.md
+docs/BACKLOG.md
+docs/ROADMAP.md
+
+The design doc should include:
+
+summary;
+entity naming decision;
+data model draft;
+user-facing UX draft;
+callback behavior;
+edge cases;
+localization notes;
+implementation ticket split;
+known limitations.
+Suggested future ticket split
+
+Recommended follow-up sequence:
+
+DIREM-032 — Check-in Data Foundation
+DIREM-033 — Check-in Buttons MVP
+DIREM-034 — Check-in History Command
+DIREM-035 — Text Check-ins
+DIREM-036 — Snooze / Later Scheduling
+Acceptance checklist
+ Check-in concept is clearly separated from Reminder and Delivery.
+ Entity naming is recommended.
+ Data model direction is drafted.
+ MVP response types are defined.
+ later is explicitly not snooze in MVP.
+ Text responses are scoped separately.
+ History is scoped separately.
+ Bunker interaction is addressed.
+ Follow-up implementation tickets are proposed.
+ No runtime code changed.
+ No migration added.
+ No release tag created.
+ No local DI-CODE reference docs staged.
+Verification commands
+git status
+git diff
+
+If code files change, stop and report.
+
+Implementation guard
+Design only.
+Do not implement check-ins.
+Do not add migrations.
+Do not change worker delivery.
+Do not add Telegram buttons/callbacks.
+Do not add history.
+Do not add text response capture.
+Do not implement snooze.
+Do not add analytics/dashboard/AI.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Expected result
+
+After this ticket:
+
+Response Check-ins are designed as a separate DIREM entity;
+implementation can proceed safely in smaller tickets;
+DIREM does not accidentally drift into task-manager architecture.


### PR DESCRIPTION
## Ticket
DIREM-031

## Done
- Added `docs/design/DIREM-031-response-checkins.md`.
- Defined Reminder / Delivery / Check-in relationships.
- Recommended `ReminderCheckIn` and `reminder_checkins` as the domain/table naming direction.
- Defined MVP response types: `done`, `later`, `skipped`.
- Documented repeat-click behavior, Bunker interaction, and why `later` is not snooze in MVP.
- Added ADR-017 for response check-ins as a separate reminder-domain entity.
- Updated roadmap/backlog planning for post-v0.2.0 and v0.3.0 response check-in work.

## Changed files
- `docs/tickets/DIREM-031-response-checkins-design.md`
- `docs/design/DIREM-031-response-checkins.md`
- `docs/DECISIONS.md`
- `docs/BACKLOG.md`
- `docs/ROADMAP.md`

## Checks
- `git status` -> clean after commit
- `git diff` -> clean after commit

## Out of scope
- No migrations.
- No SQLAlchemy models or repositories.
- No worker changes.
- No Telegram buttons/callbacks.
- No text response capture.
- No history command.
- No snooze.
- No analytics/dashboard/AI.
- No release tag.

## Notes / risks
- The exact ru/kk/en button copy is intentionally left for the implementation ticket.
- `later` is explicitly recorded-only in MVP and must not mutate `next_run_at` until a separate snooze ticket is accepted.