### PR TITLE
DIREM-032: add check-in data foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Internal `ReminderCheckIn` persistence foundation for future response check-ins.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/alembic/versions/20260503_005_create_reminder_checkins.py
+++ b/alembic/versions/20260503_005_create_reminder_checkins.py
@@ -1,0 +1,59 @@
+"""create reminder checkins
+
+Revision ID: 20260503_005_reminder_checkins
+Revises: 20260503_004_bunker_state
+Create Date: 2026-05-03
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+from direm.domain.constants import CheckInResponseType
+
+
+revision: str = "20260503_005_reminder_checkins"
+down_revision: str | None = "20260503_004_bunker_state"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reminder_checkins",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("reminder_id", sa.Integer(), nullable=False),
+        sa.Column("reminder_delivery_id", sa.Integer(), nullable=False),
+        sa.Column("response_type", sa.String(length=32), nullable=False),
+        sa.Column("response_text", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            f"response_type in ({_quoted_values(CheckInResponseType)})",
+            name="ck_reminder_checkins_response_type",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["reminder_id"], ["reminders.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["reminder_delivery_id"], ["reminder_deliveries.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("reminder_delivery_id", name="uq_reminder_checkins_delivery_id"),
+    )
+    op.create_index("ix_reminder_checkins_user_id", "reminder_checkins", ["user_id"])
+    op.create_index("ix_reminder_checkins_reminder_id", "reminder_checkins", ["reminder_id"])
+    op.create_index("ix_reminder_checkins_reminder_delivery_id", "reminder_checkins", ["reminder_delivery_id"])
+    op.create_index("ix_reminder_checkins_response_type", "reminder_checkins", ["response_type"])
+    op.create_index("ix_reminder_checkins_user_created_at", "reminder_checkins", ["user_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reminder_checkins_user_created_at", table_name="reminder_checkins")
+    op.drop_index("ix_reminder_checkins_response_type", table_name="reminder_checkins")
+    op.drop_index("ix_reminder_checkins_reminder_delivery_id", table_name="reminder_checkins")
+    op.drop_index("ix_reminder_checkins_reminder_id", table_name="reminder_checkins")
+    op.drop_index("ix_reminder_checkins_user_id", table_name="reminder_checkins")
+    op.drop_table("reminder_checkins")
+
+
+def _quoted_values(enum_type: type[CheckInResponseType]) -> str:
+    return ", ".join(f"'{item.value}'" for item in enum_type)

--- a/docs/tickets/DIREM-032-checkin-data-foundation.md
+++ b/docs/tickets/DIREM-032-checkin-data-foundation.md
@@ -1,0 +1,295 @@
+# DIREM-032 — Check-in Data Foundation
+
+## Status
+Ready for implementation
+
+## Version target
+DIREM v0.3.0 — Response Check-ins foundation
+
+## Workstream
+Backend / Domain
+
+## Recommended branch
+feature/DIREM-032-checkin-data-foundation
+
+## Purpose
+
+Add persistence foundation for user responses to delivered reminders.
+
+DIREM-031 designed Response Check-ins as a separate reminder-domain concept:
+
+```text
+Reminder = recurring intention rule and schedule
+Delivery = one concrete sent reminder message
+Check-in = user's response to that delivery
+
+This ticket implements only the data/model/repository/service foundation.
+
+It must not add Telegram buttons, callbacks, worker message buttons, history screens, text capture or snooze behavior.
+
+Source of truth
+
+Read before implementation:
+
+docs/CONCEPT.md
+docs/ARCHITECTURE.md
+docs/DECISIONS.md
+docs/design/DIREM-031-response-checkins.md
+docs/BACKLOG.md
+docs/ROADMAP.md
+docs/tickets/DIREM-032-checkin-data-foundation.md
+
+DI-CODE reference:
+
+.docs-local/DI-CODE/DI-CODE_CANON.md
+.docs-local/DI-CODE/DI-CODE_GITHUB_WORKFLOW.md
+.docs-local/DI-CODE/DI-CODE_TICKET_HANDOFF_PLAYBOOK.md
+.docs-local/DI-CODE/DI-CODE_COMMIT-ATTRIBUTION.md
+
+Important:
+
+Follow the active ticket first.
+Use DI-CODE_GITHUB_WORKFLOW.md for branch/commit/push rules.
+Use DI-CODE_COMMIT-ATTRIBUTION.md for commit credits if committing.
+Do not stage, commit or push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Current state / dependencies
+
+Assume these are accepted and merged into main:
+
+DIREM-031 — Response Check-ins Design
+
+Current behavior:
+
+worker creates reminder_deliveries for sent/failed reminders;
+delivered reminders do not yet have user response buttons;
+no ReminderCheckIn model/table exists;
+no check-in repository/service exists.
+
+Accepted design:
+
+entity name: ReminderCheckIn;
+table name: reminder_checkins;
+response types for MVP:
+done;
+later;
+skipped;
+later is only a recorded response, not snooze;
+absence of a check-in row means no response yet;
+Bunker-suppressed reminders create no delivery and therefore no check-in.
+Scope
+In scope
+
+Add persistence and domain foundation for check-ins.
+
+Need:
+
+add ReminderCheckIn SQLAlchemy model;
+add Alembic migration for reminder_checkins;
+add response type constants/enums;
+add repository methods for creating/updating and reading check-ins;
+add service methods for recording a response to a delivery;
+validate response type;
+preserve user isolation;
+link check-ins to:
+user;
+reminder;
+reminder delivery;
+allow one current check-in per delivery;
+support repeat-click behavior by updating the existing check-in row, not creating duplicates;
+preserve optional response_text column for future text check-ins;
+add tests;
+update CHANGELOG.
+Recommended table shape
+
+Follow existing project conventions for primary keys and timestamps.
+
+Expected fields:
+
+reminder_checkins
+  id
+  user_id NOT NULL FK users.id
+  reminder_id NOT NULL FK reminders.id
+  reminder_delivery_id NOT NULL FK reminder_deliveries.id
+  response_type NOT NULL
+  response_text NULL
+  created_at NOT NULL
+  updated_at NULL
+
+Constraints:
+
+unique(reminder_delivery_id)
+
+Rationale:
+
+one current check-in per delivery;
+repeat taps can update the existing response;
+future history/audit can be a separate table if needed.
+
+Indexes:
+
+user_id;
+reminder_id;
+reminder_delivery_id;
+optionally (user_id, created_at) for future history queries.
+Response types
+
+Add domain constants for:
+
+done
+later
+skipped
+
+Do not add snooze-specific response types in this ticket.
+
+Repository / service direction
+
+Suggested repository methods:
+
+ReminderCheckInRepository.get_by_delivery_id_for_user(...)
+ReminderCheckInRepository.upsert_for_delivery(...)
+ReminderCheckInRepository.list_recent_for_user(...)  # optional skeleton only if useful
+
+Suggested service method:
+
+ReminderCheckInService.record_response(...)
+
+Behavior:
+
+verify delivery belongs to current user;
+verify response type is supported;
+create check-in if absent;
+update existing check-in if one already exists for this delivery;
+do not mutate reminder schedule;
+do not mutate next_run_at;
+do not create delivery records;
+do not send Telegram messages.
+Out of scope
+
+Do not implement:
+
+worker inline check-in buttons;
+Telegram callback handler;
+/history;
+reminder details view;
+text response capture flow;
+snooze;
+changing next_run_at for later;
+analytics;
+dashboard/webhook;
+AI summaries;
+reminder editing;
+release tag.
+
+Future tickets:
+
+DIREM-033 — Check-in Buttons MVP;
+DIREM-034 — Check-in History Command;
+DIREM-035 — Text Check-ins;
+DIREM-036 — Snooze / Later Scheduling.
+Technical requirements
+Keep migration non-destructive.
+Keep timestamps UTC-aware.
+Follow existing DB/model style.
+Preserve existing delivery behavior.
+Preserve existing Bunker behavior.
+Check-in service must not treat later as snooze.
+If delivery ownership validation requires expanding delivery repository, keep it minimal and tested.
+If existing schema conventions conflict with the suggested table shape, report in the plan before implementation.
+Data / migration
+
+Expected migration:
+
+create reminder_checkins;
+add FKs to users/reminders/reminder_deliveries;
+add unique constraint on reminder_delivery_id;
+add indexes;
+downgrade drops table.
+
+No existing data backfill required.
+
+README update
+
+README update is optional.
+
+README may say only if needed:
+
+internal check-in persistence foundation exists.
+
+README must not claim:
+
+users can tap check-in buttons;
+/history exists;
+text responses exist;
+snooze exists.
+CHANGELOG update
+
+Add under [Unreleased]:
+
+- Added internal ReminderCheckIn persistence foundation for future response check-ins.
+
+Do not say check-in buttons are user-facing yet.
+
+Tests
+
+Required tests:
+
+reminder_checkins model/table metadata exists;
+migration applies cleanly;
+supported response types are defined: done/later/skipped;
+invalid response type is rejected;
+service creates check-in for a delivery belonging to current user;
+repeated response for same delivery updates existing row, not duplicate;
+response_text can be null;
+user cannot record check-in for another user's delivery;
+check-in stores user_id, reminder_id and reminder_delivery_id;
+later does not mutate reminder schedule or next_run_at;
+Bunker-related behavior remains unchanged.
+Verification commands
+python -m pytest
+python -m compileall src alembic tests
+docker compose config
+docker compose run --rm bot alembic upgrade head
+git status
+git diff
+Git / GitHub expectations
+Follow DI-CODE_GITHUB_WORKFLOW.md.
+Use feature/DIREM-032-checkin-data-foundation.
+Do not commit directly to main.
+Do not create a release tag.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+Report branch, commit, changed files, checks and push state.
+Acceptance checklist
+ ReminderCheckIn model exists.
+ reminder_checkins migration exists and applies cleanly.
+ Response type constants exist.
+ Repository/service foundation exists.
+ One current check-in per delivery is enforced.
+ Repeat response updates existing check-in.
+ User isolation is enforced.
+ later does not change schedule or next_run_at.
+ No Telegram buttons/callbacks were added.
+ No history command was added.
+ No snooze behavior was added.
+ CHANGELOG is truthful.
+ Tests pass.
+ No local DI-CODE reference docs were staged.
+ No release tag was created.
+Implementation guard
+Implement only Check-in data foundation.
+Do not add Telegram check-in buttons.
+Do not add callbacks.
+Do not modify worker delivery message markup.
+Do not implement /history.
+Do not implement text response capture.
+Do not implement snooze.
+Do not mutate reminder schedules or next_run_at.
+Do not add dashboard/webhook/AI.
+Do not stage/commit/push .docs-local/, DI-CODE/, or docs/DI-CODE/.
+If D031 design conflicts with implementation, stop and report.
+Expected result
+
+After this ticket:
+
+DIREM has a persisted ReminderCheckIn domain foundation;
+future check-in buttons can record responses safely;
+no user-facing response feature exists yet.

--- a/src/direm/db/models.py
+++ b/src/direm/db/models.py
@@ -1,9 +1,9 @@
 from datetime import datetime, time
 
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, JSON, String, Text, Time, func
+from sqlalchemy import BigInteger, Boolean, CheckConstraint, DateTime, ForeignKey, Integer, JSON, String, Text, Time, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from direm.domain.constants import DeliveryStatus, ReminderStatus
+from direm.domain.constants import CheckInResponseType, DeliveryStatus, ReminderStatus
 from direm.db.base import Base
 
 
@@ -29,6 +29,7 @@ class User(Base):
 
     reminders: Mapped[list["Reminder"]] = relationship(back_populates="user")
     deliveries: Mapped[list["ReminderDelivery"]] = relationship(back_populates="user")
+    checkins: Mapped[list["ReminderCheckIn"]] = relationship(back_populates="user")
     states: Mapped[list["UserState"]] = relationship(back_populates="user")
 
 
@@ -63,6 +64,7 @@ class Reminder(Base):
 
     user: Mapped[User] = relationship(back_populates="reminders")
     deliveries: Mapped[list["ReminderDelivery"]] = relationship(back_populates="reminder")
+    checkins: Mapped[list["ReminderCheckIn"]] = relationship(back_populates="reminder")
 
 
 class ReminderDelivery(Base):
@@ -79,6 +81,39 @@ class ReminderDelivery(Base):
 
     reminder: Mapped[Reminder] = relationship(back_populates="deliveries")
     user: Mapped[User] = relationship(back_populates="deliveries")
+    checkin: Mapped["ReminderCheckIn | None"] = relationship(back_populates="delivery", uselist=False)
+
+
+class ReminderCheckIn(Base):
+    __tablename__ = "reminder_checkins"
+    __table_args__ = (
+        CheckConstraint(
+            f"response_type in ({', '.join(repr(item.value) for item in CheckInResponseType)})",
+            name="ck_reminder_checkins_response_type",
+        ),
+        UniqueConstraint("reminder_delivery_id", name="uq_reminder_checkins_delivery_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
+    reminder_id: Mapped[int] = mapped_column(ForeignKey("reminders.id", ondelete="CASCADE"), index=True, nullable=False)
+    reminder_delivery_id: Mapped[int] = mapped_column(
+        ForeignKey("reminder_deliveries.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    response_type: Mapped[str] = mapped_column(
+        String(32),
+        index=True,
+        nullable=False,
+    )
+    response_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="checkins")
+    reminder: Mapped[Reminder] = relationship(back_populates="checkins")
+    delivery: Mapped[ReminderDelivery] = relationship(back_populates="checkin")
 
 
 class UserState(Base):

--- a/src/direm/domain/constants.py
+++ b/src/direm/domain/constants.py
@@ -16,3 +16,9 @@ class DeliveryStatus(StrEnum):
     SENT = "sent"
     FAILED = "failed"
     SKIPPED = "skipped"
+
+
+class CheckInResponseType(StrEnum):
+    DONE = "done"
+    LATER = "later"
+    SKIPPED = "skipped"

--- a/src/direm/repositories/checkins.py
+++ b/src/direm/repositories/checkins.py
@@ -1,0 +1,53 @@
+from sqlalchemy import select
+
+from direm.db.models import ReminderCheckIn, ReminderDelivery
+from direm.repositories.base import Repository
+
+
+class ReminderCheckInRepository(Repository[ReminderCheckIn]):
+    model = ReminderCheckIn
+
+    async def get_by_delivery_id_for_user(self, *, delivery_id: int, user_id: int) -> ReminderCheckIn | None:
+        result = await self.session.execute(
+            select(ReminderCheckIn).where(
+                ReminderCheckIn.reminder_delivery_id == delivery_id,
+                ReminderCheckIn.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_delivery_for_user(self, *, delivery_id: int, user_id: int) -> ReminderDelivery | None:
+        result = await self.session.execute(
+            select(ReminderDelivery).where(
+                ReminderDelivery.id == delivery_id,
+                ReminderDelivery.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert_for_delivery(
+        self,
+        *,
+        delivery: ReminderDelivery,
+        response_type: str,
+        response_text: str | None = None,
+    ) -> ReminderCheckIn:
+        checkin = await self.get_by_delivery_id_for_user(
+            delivery_id=delivery.id,
+            user_id=delivery.user_id,
+        )
+        if checkin is None:
+            checkin = ReminderCheckIn(
+                user_id=delivery.user_id,
+                reminder_id=delivery.reminder_id,
+                reminder_delivery_id=delivery.id,
+                response_type=response_type,
+                response_text=response_text,
+            )
+            self.session.add(checkin)
+        else:
+            checkin.response_type = response_type
+            checkin.response_text = response_text
+
+        await self.session.flush()
+        return checkin

--- a/src/direm/services/checkin_service.py
+++ b/src/direm/services/checkin_service.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+
+from direm.db.models import ReminderCheckIn
+from direm.domain.constants import CheckInResponseType
+from direm.repositories.checkins import ReminderCheckInRepository
+
+
+class CheckInValidationError(ValueError):
+    pass
+
+
+class CheckInDeliveryNotFoundError(CheckInValidationError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReminderCheckInResult:
+    checkin: ReminderCheckIn
+    created: bool
+
+
+class ReminderCheckInService:
+    def __init__(self, checkin_repository: ReminderCheckInRepository) -> None:
+        self.checkin_repository = checkin_repository
+
+    async def record_response(
+        self,
+        *,
+        user_id: int,
+        delivery_id: int,
+        response_type: str,
+        response_text: str | None = None,
+    ) -> ReminderCheckInResult:
+        normalized_response_type = self._validate_response_type(response_type)
+        delivery = await self.checkin_repository.get_delivery_for_user(
+            delivery_id=delivery_id,
+            user_id=user_id,
+        )
+        if delivery is None:
+            raise CheckInDeliveryNotFoundError("Reminder delivery was not found for this user.")
+
+        existing = await self.checkin_repository.get_by_delivery_id_for_user(
+            delivery_id=delivery_id,
+            user_id=user_id,
+        )
+        checkin = await self.checkin_repository.upsert_for_delivery(
+            delivery=delivery,
+            response_type=normalized_response_type,
+            response_text=response_text,
+        )
+        return ReminderCheckInResult(checkin=checkin, created=existing is None)
+
+    def _validate_response_type(self, response_type: str) -> str:
+        try:
+            return CheckInResponseType(response_type).value
+        except ValueError as exc:
+            raise CheckInValidationError(f"Unsupported check-in response type: {response_type}") from exc

--- a/tests/unit/test_checkin_service.py
+++ b/tests/unit/test_checkin_service.py
@@ -1,0 +1,194 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from direm.db.base import Base
+from direm.db.models import Reminder, ReminderCheckIn
+from direm.domain.constants import CheckInResponseType, DeliveryStatus, ReminderStatus, ScheduleType
+from direm.repositories.checkins import ReminderCheckInRepository
+from direm.repositories.deliveries import ReminderDeliveryRepository
+from direm.repositories.users import UserRepository
+from direm.services.checkin_service import (
+    CheckInDeliveryNotFoundError,
+    CheckInValidationError,
+    ReminderCheckInService,
+)
+from direm.services.user_service import TelegramUserProfile, UserService
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    yield async_sessionmaker(engine, expire_on_commit=False)
+
+    await engine.dispose()
+
+
+async def create_user(session, telegram_user_id: int):
+    return await UserService(UserRepository(session)).register_or_update_from_telegram(
+        TelegramUserProfile(
+            telegram_user_id=telegram_user_id,
+            chat_id=telegram_user_id + 1000,
+            username=f"user{telegram_user_id}",
+            first_name="User",
+            language_code="en",
+        )
+    )
+
+
+async def create_reminder(session, user, *, next_run_at: datetime):
+    reminder = Reminder(
+        user_id=user.id,
+        title="Morning focus",
+        message_text="Return to intent.",
+        schedule_type=ScheduleType.INTERVAL.value,
+        interval_minutes=30,
+        timezone=user.timezone,
+        status=ReminderStatus.ACTIVE.value,
+        next_run_at=next_run_at,
+    )
+    session.add(reminder)
+    await session.flush()
+    return reminder
+
+
+async def create_delivery(session, user, reminder):
+    return await ReminderDeliveryRepository(session).create(
+        reminder_id=reminder.id,
+        user_id=user.id,
+        scheduled_for=reminder.next_run_at,
+        status=DeliveryStatus.SENT.value,
+        sent_at=datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
+    )
+
+
+async def list_checkins(session) -> list[ReminderCheckIn]:
+    result = await session.execute(select(ReminderCheckIn).order_by(ReminderCheckIn.id.asc()))
+    return list(result.scalars().all())
+
+
+async def test_record_response_creates_checkin_for_user_delivery(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session, 1001)
+        reminder = await create_reminder(session, user, next_run_at=datetime(2026, 5, 3, 8, 30, tzinfo=UTC))
+        delivery = await create_delivery(session, user, reminder)
+
+        result = await ReminderCheckInService(ReminderCheckInRepository(session)).record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.DONE.value,
+        )
+
+        assert result.created is True
+        assert result.checkin.user_id == user.id
+        assert result.checkin.reminder_id == reminder.id
+        assert result.checkin.reminder_delivery_id == delivery.id
+        assert result.checkin.response_type == CheckInResponseType.DONE.value
+        assert result.checkin.response_text is None
+
+
+async def test_repeated_response_updates_existing_checkin_instead_of_duplicate(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session, 1001)
+        reminder = await create_reminder(session, user, next_run_at=datetime(2026, 5, 3, 8, 30, tzinfo=UTC))
+        delivery = await create_delivery(session, user, reminder)
+        service = ReminderCheckInService(ReminderCheckInRepository(session))
+
+        first = await service.record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.DONE.value,
+        )
+        second = await service.record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.SKIPPED.value,
+        )
+
+        checkins = await list_checkins(session)
+        assert first.created is True
+        assert second.created is False
+        assert first.checkin.id == second.checkin.id
+        assert len(checkins) == 1
+        assert checkins[0].response_type == CheckInResponseType.SKIPPED.value
+
+
+async def test_invalid_response_type_is_rejected(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session, 1001)
+        reminder = await create_reminder(session, user, next_run_at=datetime(2026, 5, 3, 8, 30, tzinfo=UTC))
+        delivery = await create_delivery(session, user, reminder)
+
+        with pytest.raises(CheckInValidationError):
+            await ReminderCheckInService(ReminderCheckInRepository(session)).record_response(
+                user_id=user.id,
+                delivery_id=delivery.id,
+                response_type="snooze",
+            )
+
+        assert await list_checkins(session) == []
+
+
+async def test_user_cannot_record_checkin_for_another_users_delivery(session_factory) -> None:
+    async with session_factory() as session:
+        owner = await create_user(session, 1001)
+        other = await create_user(session, 1002)
+        reminder = await create_reminder(session, owner, next_run_at=datetime(2026, 5, 3, 8, 30, tzinfo=UTC))
+        delivery = await create_delivery(session, owner, reminder)
+
+        with pytest.raises(CheckInDeliveryNotFoundError):
+            await ReminderCheckInService(ReminderCheckInRepository(session)).record_response(
+                user_id=other.id,
+                delivery_id=delivery.id,
+                response_type=CheckInResponseType.DONE.value,
+            )
+
+        assert await list_checkins(session) == []
+
+
+async def test_response_text_may_be_null_or_updated_by_foundation(session_factory) -> None:
+    async with session_factory() as session:
+        user = await create_user(session, 1001)
+        reminder = await create_reminder(session, user, next_run_at=datetime(2026, 5, 3, 8, 30, tzinfo=UTC))
+        delivery = await create_delivery(session, user, reminder)
+        service = ReminderCheckInService(ReminderCheckInRepository(session))
+
+        created = await service.record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.LATER.value,
+        )
+        assert created.checkin.response_text is None
+
+        updated = await service.record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.LATER.value,
+            response_text="Future text foundation.",
+        )
+
+        assert updated.checkin.response_text == "Future text foundation."
+
+
+async def test_later_does_not_mutate_reminder_schedule_or_next_run(session_factory) -> None:
+    async with session_factory() as session:
+        next_run_at = datetime(2026, 5, 3, 8, 30, tzinfo=UTC)
+        user = await create_user(session, 1001)
+        reminder = await create_reminder(session, user, next_run_at=next_run_at)
+        delivery = await create_delivery(session, user, reminder)
+
+        await ReminderCheckInService(ReminderCheckInRepository(session)).record_response(
+            user_id=user.id,
+            delivery_id=delivery.id,
+            response_type=CheckInResponseType.LATER.value,
+        )
+
+        assert reminder.schedule_type == ScheduleType.INTERVAL.value
+        assert reminder.interval_minutes == 30
+        assert reminder.next_run_at == next_run_at
+        assert delivery.status == DeliveryStatus.SENT.value

--- a/tests/unit/test_domain_constants.py
+++ b/tests/unit/test_domain_constants.py
@@ -1,4 +1,4 @@
-from direm.domain.constants import DeliveryStatus, ReminderStatus, ScheduleType
+from direm.domain.constants import CheckInResponseType, DeliveryStatus, ReminderStatus, ScheduleType
 
 
 def test_schedule_type_values_are_stable() -> None:
@@ -11,3 +11,7 @@ def test_reminder_status_values_are_stable() -> None:
 
 def test_delivery_status_values_are_stable() -> None:
     assert [item.value for item in DeliveryStatus] == ["sent", "failed", "skipped"]
+
+
+def test_checkin_response_type_values_are_stable() -> None:
+    assert [item.value for item in CheckInResponseType] == ["done", "later", "skipped"]

--- a/tests/unit/test_schema_metadata.py
+++ b/tests/unit/test_schema_metadata.py
@@ -1,9 +1,15 @@
 from direm.db.base import Base
-from direm.db.models import Reminder, ReminderDelivery, User, UserState
+from direm.db.models import Reminder, ReminderCheckIn, ReminderDelivery, User, UserState
 
 
 def test_domain_tables_are_registered() -> None:
-    assert {"users", "reminders", "reminder_deliveries", "user_states"}.issubset(Base.metadata.tables)
+    assert {
+        "users",
+        "reminders",
+        "reminder_deliveries",
+        "reminder_checkins",
+        "user_states",
+    }.issubset(Base.metadata.tables)
 
 
 def test_users_table_has_language_code() -> None:
@@ -49,6 +55,29 @@ def test_delivery_table_has_foundation_columns() -> None:
         assert name in columns
 
 
+def test_reminder_checkins_table_has_foundation_columns() -> None:
+    columns = ReminderCheckIn.__table__.columns
+
+    for name in (
+        "id",
+        "user_id",
+        "reminder_id",
+        "reminder_delivery_id",
+        "response_type",
+        "response_text",
+        "created_at",
+        "updated_at",
+    ):
+        assert name in columns
+
+
+def test_reminder_checkins_enforce_one_current_response_per_delivery() -> None:
+    constraints = {constraint.name for constraint in ReminderCheckIn.__table__.constraints}
+
+    assert "uq_reminder_checkins_delivery_id" in constraints
+    assert "ck_reminder_checkins_response_type" in constraints
+
+
 def test_user_states_table_has_foundation_columns() -> None:
     columns = UserState.__table__.columns
 
@@ -59,4 +88,7 @@ def test_user_states_table_has_foundation_columns() -> None:
 def test_relationships_are_declared_without_business_logic() -> None:
     assert Reminder.user.property.mapper.class_ is User
     assert ReminderDelivery.reminder.property.mapper.class_ is Reminder
+    assert ReminderCheckIn.user.property.mapper.class_ is User
+    assert ReminderCheckIn.reminder.property.mapper.class_ is Reminder
+    assert ReminderCheckIn.delivery.property.mapper.class_ is ReminderDelivery
     assert UserState.user.property.mapper.class_ is User


### PR DESCRIPTION
## Ticket
DIREM-032

## Done
- Added `ReminderCheckIn` SQLAlchemy model and relationships to user, reminder and reminder delivery.
- Added `reminder_checkins` Alembic migration.
- Added `CheckInResponseType` constants: `done`, `later`, `skipped`.
- Added `ReminderCheckInRepository` and `ReminderCheckInService.record_response(...)`.
- Enforced one current check-in per delivery with `UNIQUE(reminder_delivery_id)`.
- Preserved user isolation by validating delivery ownership before recording a check-in.
- Kept `later` as a recorded response only, with no schedule or `next_run_at` mutation.
- Updated tests and CHANGELOG.

## Changed files
- `CHANGELOG.md`
- `alembic/versions/20260503_005_create_reminder_checkins.py`
- `docs/tickets/DIREM-032-checkin-data-foundation.md`
- `src/direm/db/models.py`
- `src/direm/domain/constants.py`
- `src/direm/repositories/checkins.py`
- `src/direm/services/checkin_service.py`
- `tests/unit/test_checkin_service.py`
- `tests/unit/test_domain_constants.py`
- `tests/unit/test_schema_metadata.py`

## Checks
- `python -m pytest` -> 185 passed
- `python -m compileall src alembic tests` -> passed
- `docker compose config` -> passed
- `docker compose build bot worker` -> passed before migration verification so the new migration was present in the image
- `docker compose run --rm bot alembic upgrade head` -> passed
- `docker compose run --rm bot alembic current` -> `20260503_005_reminder_checkins (head)`
- `git status` -> clean after commit
- `git diff` -> clean after commit

## Out of scope
- No worker inline buttons.
- No Telegram callbacks.
- No worker message markup changes.
- No `/history`.
- No text response capture flow.
- No snooze or `next_run_at` changes.
- No analytics/dashboard/AI.
- No release tag.

## Notes / risks
- `response_text` is nullable foundation only; no user-facing text capture is implemented.
- `later` is persisted exactly like the other MVP response types and does not affect reminder scheduling.